### PR TITLE
Remove britishcolumbia.jp from gsc config

### DIFF
--- a/google-api/google_search.json
+++ b/google-api/google_search.json
@@ -74,10 +74,6 @@
       "start_date_default": "2019-02-02"
     },
     {
-      "name": "https://www.britishcolumbia.jp/",
-      "start_date_default": "2019-02-02"
-    },
-    {
       "name": "https://energystepcode.ca/",
       "start_date_default": "2020-08-12"
     },


### PR DESCRIPTION
Domain has transitioned to britishcolumbia.ca/japan in gsc