### PR TITLE
Adding and updating history table DDLs

### DIFF
--- a/s3_to_redshift/ddl/microservice.history.sql
+++ b/s3_to_redshift/ddl/microservice.history.sql
@@ -1,40 +1,46 @@
-CREATE TABLE servicebc.history
+--DROP TABLE microservice.history;
+CREATE TABLE IF NOT EXISTS microservice.history
 (
-  "id" INT NOT NULL ENCODE ZSTD,
-  "user_id" INT ENCODE ZSTD,
-  "title" VARCHAR(255) ENCODE ZSTD,
-  "created_at" TIMESTAMP SORTKEY ENCODE ZSTD,
-  "query_id" INT ENCODE ZSTD,
-  "look_id" INT ENCODE ZSTD,
-  "runtime" DOUBLE PRECISION ENCODE ZSTD,
-  "source" VARCHAR(255) ENCODE ZSTD,
-  "node_id" INT ENCODE ZSTD,
-  "status" VARCHAR(255) ENCODE ZSTD,
-  "slug" VARCHAR(255) ENCODE ZSTD,
-  "cache_key" VARCHAR(255) ENCODE ZSTD,
-  "result_source" VARCHAR(255) ENCODE ZSTD,
-  "message" VARCHAR(1024) ENCODE ZSTD,
-  "connection_name" VARCHAR(255) ENCODE ZSTD,
-  "connection_id" VARCHAR(255) ENCODE ZSTD,
-  "dialect" VARCHAR(255) ENCODE ZSTD,
-  "completed_at" TIMESTAMP ENCODE ZSTD,
-  "force_production" INT ENCODE ZSTD,
-  "generate_links" INT ENCODE ZSTD,
-  "path_prefix_id" INT ENCODE ZSTD,
-  "cache" INT ENCODE ZSTD,
-  "cache_only" INT ENCODE ZSTD,
-  "sql_query_id" INT ENCODE ZSTD,
-  "render_key" VARCHAR(255) ENCODE ZSTD,
-  "rebuild_pdts" INT ENCODE ZSTD,
-  "server_table_calcs" INT ENCODE ZSTD,
-  "dashboard_id" VARCHAR(255) ENCODE ZSTD,
-  "result_format" VARCHAR(255) ENCODE ZSTD,
-  "apply_formatting" INT ENCODE ZSTD,
-  "dashboard_session" VARCHAR(255) ENCODE ZSTD,
-  "apply_vis" INT ENCODE ZSTD,
-  "models_dir" VARCHAR(255) ENCODE ZSTD,
-  "workspace_id" VARCHAR(255) ENCODE ZSTD,
-  "result_maker_id" INT ENCODE ZSTD
-);
-
-GRANT SELECT ON servicebc.history TO "looker";
+        id INTEGER NOT NULL  ENCODE zstd
+        ,user_id INTEGER   ENCODE zstd
+        ,title VARCHAR(255)   ENCODE zstd
+        ,created_at TIMESTAMP WITHOUT TIME ZONE   ENCODE RAW
+        ,query_id INTEGER   ENCODE zstd
+        ,look_id INTEGER   ENCODE zstd
+        ,runtime DOUBLE PRECISION   ENCODE zstd
+        ,source VARCHAR(255)   ENCODE zstd
+        ,node_id INTEGER   ENCODE zstd
+        ,status VARCHAR(255)   ENCODE zstd
+        ,slug VARCHAR(255)   ENCODE zstd
+        ,cache_key VARCHAR(255)   ENCODE zstd
+        ,result_source VARCHAR(255)   ENCODE zstd
+        ,message VARCHAR(1024)   ENCODE zstd
+        ,connection_name VARCHAR(255)   ENCODE zstd
+        ,connection_id VARCHAR(255)   ENCODE zstd
+        ,dialect VARCHAR(255)   ENCODE zstd
+        ,completed_at TIMESTAMP WITHOUT TIME ZONE   ENCODE zstd
+        ,force_production INTEGER   ENCODE zstd
+        ,generate_links INTEGER   ENCODE zstd
+        ,path_prefix_id INTEGER   ENCODE zstd
+        ,"cache" INTEGER   ENCODE zstd
+        ,cache_only INTEGER   ENCODE zstd
+        ,sql_query_id INTEGER   ENCODE zstd
+        ,render_key VARCHAR(255)   ENCODE zstd
+        ,rebuild_pdts INTEGER   ENCODE zstd
+        ,server_table_calcs INTEGER   ENCODE zstd
+        ,dashboard_id VARCHAR(255)   ENCODE zstd
+        ,result_format VARCHAR(255)   ENCODE zstd
+        ,apply_formatting INTEGER   ENCODE zstd
+        ,dashboard_session VARCHAR(255)   ENCODE zstd
+        ,apply_vis INTEGER   ENCODE zstd
+        ,models_dir VARCHAR(255)   ENCODE zstd
+        ,workspace_id VARCHAR(255)   ENCODE zstd
+        ,result_maker_id INTEGER   ENCODE zstd
+)
+DISTSTYLE AUTO
+ SORTKEY (
+        created_at
+        )
+;
+ALTER TABLE microservice.history owner to microservice;
+GRANT SELECT ON servicebc.history to looker;

--- a/s3_to_redshift/ddl/servicebc.history.sql
+++ b/s3_to_redshift/ddl/servicebc.history.sql
@@ -1,0 +1,46 @@
+--DROP TABLE servicebc.history;
+CREATE TABLE IF NOT EXISTS servicebc.history
+(
+        id INTEGER NOT NULL  ENCODE zstd
+        ,user_id INTEGER   ENCODE zstd
+        ,title VARCHAR(255)   ENCODE zstd
+        ,created_at TIMESTAMP WITHOUT TIME ZONE   ENCODE RAW
+        ,query_id INTEGER   ENCODE zstd
+        ,look_id INTEGER   ENCODE zstd
+        ,runtime DOUBLE PRECISION   ENCODE zstd
+        ,source VARCHAR(255)   ENCODE zstd
+        ,node_id INTEGER   ENCODE zstd
+        ,status VARCHAR(255)   ENCODE zstd
+        ,slug VARCHAR(255)   ENCODE zstd
+        ,cache_key VARCHAR(255)   ENCODE zstd
+        ,result_source VARCHAR(255)   ENCODE zstd
+        ,message VARCHAR(512)   ENCODE zstd
+        ,connection_name VARCHAR(255)   ENCODE zstd
+        ,connection_id VARCHAR(255)   ENCODE zstd
+        ,dialect VARCHAR(255)   ENCODE zstd
+        ,completed_at TIMESTAMP WITHOUT TIME ZONE   ENCODE zstd
+        ,force_production INTEGER   ENCODE zstd
+        ,generate_links INTEGER   ENCODE zstd
+        ,path_prefix_id INTEGER   ENCODE zstd
+        ,"cache" INTEGER   ENCODE zstd
+        ,cache_only INTEGER   ENCODE zstd
+        ,sql_query_id INTEGER   ENCODE zstd
+        ,render_key VARCHAR(255)   ENCODE zstd
+        ,rebuild_pdts INTEGER   ENCODE zstd
+        ,server_table_calcs INTEGER   ENCODE zstd
+        ,dashboard_id VARCHAR(255)   ENCODE zstd
+        ,result_format VARCHAR(255)   ENCODE zstd
+        ,apply_formatting INTEGER   ENCODE zstd
+        ,dashboard_session VARCHAR(255)   ENCODE zstd
+        ,apply_vis INTEGER   ENCODE zstd
+        ,models_dir VARCHAR(255)   ENCODE zstd
+        ,workspace_id VARCHAR(255)   ENCODE zstd
+        ,result_maker_id INTEGER   ENCODE zstd
+)
+DISTSTYLE AUTO
+ SORTKEY (
+        created_at
+        )
+;
+ALTER TABLE servicebc.history owner to microservice;
+GRANT SELECT ON servicebc.history to looker;


### PR DESCRIPTION
Updated `microservice.history` DDL and added `servicebc.history` DDL (which exists on cluster but didn't exist in source control).