### PR TITLE
GDXDSD-5429 sdpr incremental update and hourly data - In draft waiting on SDPR

### DIFF
--- a/sfts/config.d/sdpr_hourly.json
+++ b/sfts/config.d/sdpr_hourly.json
@@ -1,0 +1,11 @@
+{
+  "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
+  "source": "client",
+  "directory": "doug_test/hourly",
+  "destination": "processed",
+  "object_prefix": "sdpr",
+  "dml": "sdpr_hourly.sql",
+  "header": true,
+  "extension": ".csv",
+  "delimiter": ","
+}

--- a/sfts/config.d/sdpr_hourly.json
+++ b/sfts/config.d/sdpr_hourly.json
@@ -1,9 +1,9 @@
 {
   "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
   "source": "client",
-  "directory": "doug_test/hourly",
+  "directory": "theq_sdpr/hourly/Oct_2022_incremental_update",
   "destination": "processed",
-  "object_prefix": "sdpr",
+  "object_prefix": "sdpr_hourly",
   "dml": "sdpr_hourly.sql",
   "header": true,
   "extension": ".csv",

--- a/sfts/config.d/sdpr_last_full_day_incremental.json
+++ b/sfts/config.d/sdpr_last_full_day_incremental.json
@@ -6,5 +6,6 @@
   "object_prefix": "sdpr",
   "dml": "sdpr_last_full_day_incremental.sql",
   "header": true,
-  "extension": ".csv"
+  "extension": ".csv",
+  "delimiter": ","
 }

--- a/sfts/config.d/sdpr_last_full_day_incremental.json
+++ b/sfts/config.d/sdpr_last_full_day_incremental.json
@@ -1,9 +1,9 @@
 {
   "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
   "source": "client",
-  "directory": "doug_test/daily",
+  "directory": "theq_sdpr/daily/Oct_2022_incremental_update",
   "destination": "processed",
-  "object_prefix": "sdpr",
+  "object_prefix": "sdpr_daily",
   "dml": "sdpr_last_full_day_incremental.sql",
   "header": true,
   "extension": ".csv",

--- a/sfts/config.d/sdpr_last_full_day_incremental.json
+++ b/sfts/config.d/sdpr_last_full_day_incremental.json
@@ -1,0 +1,10 @@
+{
+  "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
+  "source": "client",
+  "directory": "doug_test/daily",
+  "destination": "processed",
+  "object_prefix": "sdpr",
+  "dml": "sdpr_last_full_day_incremental.sql",
+  "header": true,
+  "extension": ".csv"
+}

--- a/sfts/dml/sdpr_hourly.sql
+++ b/sfts/dml/sdpr_hourly.sql
@@ -34,8 +34,8 @@ SELECT * FROM (
     FROM
         "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
     WHERE
-        ("welcome_time") >= CONVERT_TIMEZONE(''America\Vancouver'', ((DATEADD(day,0, DATE_TRUNC(''day'',GETDATE()) )))) AND
-        ("welcome_time") < CONVERT_TIMEZONE(''America\Vancouver'', ((DATEADD(hour,0, DATE_TRUNC(''hour'', GETDATE()) )))) AND  
+        ("welcome_time") >= CONVERT_TIMEZONE(''America/\Vancouver'', ((DATEADD(day,0, DATE_TRUNC(''day'',GETDATE()) )))) AND
+        ("welcome_time") < CONVERT_TIMEZONE(''America/\Vancouver'', ((DATEADD(hour,0, DATE_TRUNC(''hour'', GETDATE()) )))) AND  
         (TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''),''.'','''') ) IS NOT NULL
     GROUP BY
         "theq_sdpr_poc.date",

--- a/sfts/dml/sdpr_hourly.sql
+++ b/sfts/dml/sdpr_hourly.sql
@@ -35,7 +35,7 @@ SELECT * FROM (
         "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
     WHERE
         ("welcome_time") >= ((DATEADD(day,0, DATE_TRUNC(''day'',GETDATE()) ))) AND
-        ("welcome_time") < ((DATEADD(hour,-1, DATE_TRUNC(''hour'', GETDATE()) ))) AND  
+        ("welcome_time") < ((DATEADD(hour,0, DATE_TRUNC(''hour'', GETDATE()) ))) AND  
         (TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''),''.'','''') ) IS NOT NULL
     GROUP BY
         "theq_sdpr_poc.date",

--- a/sfts/dml/sdpr_hourly.sql
+++ b/sfts/dml/sdpr_hourly.sql
@@ -34,8 +34,8 @@ SELECT * FROM (
     FROM
         "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
     WHERE
-        ("welcome_time") >= ((DATEADD(day,0, DATE_TRUNC(''day'',GETDATE()) ))) AND
-        ("welcome_time") < ((DATEADD(hour,0, DATE_TRUNC(''hour'', GETDATE()) ))) AND  
+        ("welcome_time") >= CONVERT_TIMEZONE('America\Vancouver', ((DATEADD(day,0, DATE_TRUNC(''day'',GETDATE()) )))) AND
+        ("welcome_time") < CONVERT_TIMEZONE('America\Vancouver', ((DATEADD(hour,0, DATE_TRUNC(''hour'', GETDATE()) )))) AND  
         (TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''),''.'','''') ) IS NOT NULL
     GROUP BY
         "theq_sdpr_poc.date",

--- a/sfts/dml/sdpr_hourly.sql
+++ b/sfts/dml/sdpr_hourly.sql
@@ -1,0 +1,66 @@
+SELECT * FROM (
+    SELECT
+        (DATE("welcome_time")) AS "theq_sdpr_poc.date",
+            (TO_CHAR(DATE_TRUNC(''second'', "welcome_time"), ''YYYY-MM-DD HH24:MI:SS'')) AS "theq_sdpr_poc.welcome_time",
+            (TO_CHAR(DATE_TRUNC(''second'', "latest_time"), ''YYYY-MM-DD HH24:MI:SS'')) AS "theq_sdpr_poc.latest_time",
+        "office_id" AS "theq_sdpr_poc.office_id",
+        "office_name" AS "theq_sdpr_poc.office_name",
+        "agent_id" AS "theq_sdpr_poc.agent_id",
+        "idir" AS "theq_sdpr_poc.idir",
+        "client_id" AS "theq_sdpr_poc.client_id",
+        "back_office" AS "theq_sdpr_poc.back_office",
+        "channel_sort" AS "theq_sdpr_poc.channel_sort",
+        "channel" AS "theq_sdpr_poc.channel",
+        "counter_type" AS "theq_sdpr_poc.counter_type",
+            (CASE WHEN "inaccurate_time" THEN ''Yes'' ELSE ''No'' END) AS "theq_sdpr_poc.inaccurate_time",
+            (CASE WHEN "no_wait_visit" THEN ''Yes'' ELSE ''No'' END) AS "theq_sdpr_poc.no_wait_visit",
+        "program_name" AS "theq_sdpr_poc.program_name",
+        "transaction_name" AS "theq_sdpr_poc.transaction_name",
+        "service_count" AS "theq_sdpr_poc.service_count",
+        COALESCE(theq_sdpr_poc.status, ''Open Ticket'') AS "theq_sdpr_poc.status",
+        theq_sdpr_poc.hold_duration_zscore AS "theq_sdpr_poc.hold_duration_zscore",
+        theq_sdpr_poc.prep_duration_zscore AS "theq_sdpr_poc.prep_duration_zscore",
+        theq_sdpr_poc.serve_duration_zscore AS "theq_sdpr_poc.serve_duration_zscore",
+        theq_sdpr_poc.service_creation_duration_zscore AS "theq_sdpr_poc.service_creation_duration_zscore",
+        theq_sdpr_poc.waiting_duration_zscore AS "theq_sdpr_poc.waiting_duration_zscore",
+        COUNT(DISTINCT theq_sdpr_poc.client_id ) AS "theq_sdpr_poc.visits_count",
+        COUNT(*) AS "theq_sdpr_poc.services_count",
+        COALESCE(SUM(theq_sdpr_poc.transaction_count ), 0) AS "theq_sdpr_poc.transactions_count",
+        AVG((1.00 * theq_sdpr_poc.service_creation_duration)/(60*60*24) ) AS "theq_sdpr_poc.service_creation_duration_per_visit_average",
+        AVG((1.00 * theq_sdpr_poc.waiting_duration)/(60*60*24) ) AS "theq_sdpr_poc.waiting_duration_per_service_average",
+        AVG((1.00 * theq_sdpr_poc.prep_duration)/(60*60*24) ) AS "theq_sdpr_poc.prep_duration_per_service_average",
+        AVG((1.00 * theq_sdpr_poc.serve_duration)/(60*60*24) ) AS "theq_sdpr_poc.serve_duration_per_service_average",
+        AVG((1.00 * theq_sdpr_poc.hold_duration)/(60*60*24) ) AS "theq_sdpr_poc.hold_duration_per_service_average"
+    FROM
+        "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
+    WHERE
+        ("welcome_time") >= ((DATEADD(day,0, DATE_TRUNC(''day'',GETDATE()) ))) AND
+        ("welcome_time") < ((DATEADD(hour,-1, DATE_TRUNC(''hour'', GETDATE()) ))) AND  
+        (TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''),''.'','''') ) IS NOT NULL
+    GROUP BY
+        "theq_sdpr_poc.date",
+        "theq_sdpr_poc.welcome_time",
+        "theq_sdpr_poc.latest_time",
+        "theq_sdpr_poc.office_id",
+        "theq_sdpr_poc.office_name",
+        "theq_sdpr_poc.agent_id",
+        "theq_sdpr_poc.idir",
+        "theq_sdpr_poc.client_id",
+        "theq_sdpr_poc.back_office",
+        "theq_sdpr_poc.channel_sort",
+        "theq_sdpr_poc.channel",
+        "theq_sdpr_poc.counter_type",
+        "theq_sdpr_poc.inaccurate_time",
+        "theq_sdpr_poc.no_wait_visit",
+        "theq_sdpr_poc.program_name",
+        "theq_sdpr_poc.transaction_name",
+        "theq_sdpr_poc.service_count",
+        "theq_sdpr_poc.status",
+        "theq_sdpr_poc.hold_duration_zscore",
+        "theq_sdpr_poc.prep_duration_zscore",
+        "theq_sdpr_poc.serve_duration_zscore",
+        "theq_sdpr_poc.service_creation_duration_zscore",
+        "theq_sdpr_poc.waiting_duration_zscore"
+    ORDER BY
+        "theq_sdpr_poc.welcome_time"
+)

--- a/sfts/dml/sdpr_hourly.sql
+++ b/sfts/dml/sdpr_hourly.sql
@@ -34,8 +34,8 @@ SELECT * FROM (
     FROM
         "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
     WHERE
-        ("welcome_time") >= CONVERT_TIMEZONE('America\Vancouver', ((DATEADD(day,0, DATE_TRUNC(''day'',GETDATE()) )))) AND
-        ("welcome_time") < CONVERT_TIMEZONE('America\Vancouver', ((DATEADD(hour,0, DATE_TRUNC(''hour'', GETDATE()) )))) AND  
+        ("welcome_time") >= CONVERT_TIMEZONE(''America\Vancouver'', ((DATEADD(day,0, DATE_TRUNC(''day'',GETDATE()) )))) AND
+        ("welcome_time") < CONVERT_TIMEZONE(''America\Vancouver'', ((DATEADD(hour,0, DATE_TRUNC(''hour'', GETDATE()) )))) AND  
         (TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''),''.'','''') ) IS NOT NULL
     GROUP BY
         "theq_sdpr_poc.date",

--- a/sfts/dml/sdpr_hourly.sql
+++ b/sfts/dml/sdpr_hourly.sql
@@ -34,8 +34,8 @@ SELECT * FROM (
     FROM
         "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
     WHERE
-        ("welcome_time") >= CONVERT_TIMEZONE(''America/\Vancouver'', ((DATEADD(day,0, DATE_TRUNC(''day'',GETDATE()) )))) AND
-        ("welcome_time") < CONVERT_TIMEZONE(''America/\Vancouver'', ((DATEADD(hour,0, DATE_TRUNC(''hour'', GETDATE()) )))) AND  
+        ("welcome_time") >= ((DATEADD(day,0, DATE_TRUNC(''day'',CONVERT_TIMEZONE(''America/\Vancouver'', GETDATE())) ))) AND
+        ("welcome_time") < ((DATEADD(hour,0, DATE_TRUNC(''hour'', CONVERT_TIMEZONE(''America/\Vancouver'', GETDATE())) ))) AND  
         (TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''),''.'','''') ) IS NOT NULL
     GROUP BY
         "theq_sdpr_poc.date",

--- a/sfts/dml/sdpr_last_full_day_incremental.sql
+++ b/sfts/dml/sdpr_last_full_day_incremental.sql
@@ -36,8 +36,8 @@ SELECT * FROM (
         FROM
             "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
         WHERE
-            ((( "welcome_time" ) >= ((DATEADD(day,-1, DATE_TRUNC(''day'',CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME)) ))) AND
-            ( "welcome_time" ) < ((DATEADD(day,1, DATEADD(day,-1, DATE_TRUNC(''day'',CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME)) ) ))))) AND
+            ((( "welcome_time" ) >= ((DATEADD(day,-1, DATE_TRUNC(''day'',GETDATE()) ))) AND
+            ( "welcome_time" ) < ((DATEADD(day,1, DATEADD(day,-1, DATE_TRUNC(''day'',GETDATE()) ) ))))) AND
             (TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''),''.'','''') ) IS NOT NULL
         GROUP BY
             "update_flag",
@@ -102,10 +102,9 @@ SELECT * FROM (
         FROM
             "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
         WHERE
-            "welcome_time" < DATEADD(day, -1, DATE_TRUNC(''day'', CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME)))
-            AND "latest_time" >= DATEADD(day, -1, DATE_TRUNC(''day'', CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME)))
-            AND "latest_time" < DATEADD(day, 1, DATEADD(day, -1, DATE_TRUNC(''day'', CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME))))
-            AND TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''), ''.'', '''') IS NOT NULL
+            ("welcome_time") < ((DATEADD(day,-1, DATE_TRUNC(''day'',GETDATE()) ))) AND 
+            ((( "latest_time" ) >= ((DATEADD(day,-1, DATE_TRUNC(''day'',GETDATE()) ))) AND ( "latest_time" ) < ((DATEADD(day,1, DATEADD(day,-1, DATE_TRUNC(''day'',GETDATE()) ) ))))) AND 
+            (TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''),''.'','''') ) IS NOT NULL
         GROUP BY
             "update_flag",
             "theq_sdpr_poc.date",

--- a/sfts/dml/sdpr_last_full_day_incremental.sql
+++ b/sfts/dml/sdpr_last_full_day_incremental.sql
@@ -1,0 +1,138 @@
+SELECT * FROM (
+    WITH "new_rows" AS (
+        SELECT
+            0 AS "update_flag",
+            (DATE("welcome_time")) AS "theq_sdpr_poc.date",
+                (TO_CHAR(DATE_TRUNC(''second'', "welcome_time"), ''YYYY-MM-DD HH24:MI:SS'')) AS "theq_sdpr_poc.welcome_time",
+                (TO_CHAR(DATE_TRUNC(''second'', "latest_time"), ''YYYY-MM-DD HH24:MI:SS'')) AS "theq_sdpr_poc.latest_time",
+            "office_id" AS "theq_sdpr_poc.office_id",
+            "office_name" AS "theq_sdpr_poc.office_name",
+            "agent_id" AS "theq_sdpr_poc.agent_id",
+            "idir" AS "theq_sdpr_poc.idir",
+            "client_id" AS "theq_sdpr_poc.client_id",
+            "back_office" AS "theq_sdpr_poc.back_office",
+            "channel_sort" AS "theq_sdpr_poc.channel_sort",
+            "channel" AS "theq_sdpr_poc.channel",
+            "counter_type" AS "theq_sdpr_poc.counter_type",
+                (CASE WHEN "inaccurate_time" THEN ''Yes'' ELSE ''No'' END) AS "theq_sdpr_poc.inaccurate_time",
+                (CASE WHEN "no_wait_visit" THEN ''Yes'' ELSE ''No'' END) AS "theq_sdpr_poc.no_wait_visit",
+            "program_name" AS "theq_sdpr_poc.program_name",
+            "transaction_name" AS "theq_sdpr_poc.transaction_name",
+            "service_count" AS "theq_sdpr_poc.service_count",
+            COALESCE(theq_sdpr_poc.status, ''Open Ticket'') AS "theq_sdpr_poc.status",
+            theq_sdpr_poc.hold_duration_zscore AS "theq_sdpr_poc.hold_duration_zscore",
+            theq_sdpr_poc.prep_duration_zscore AS "theq_sdpr_poc.prep_duration_zscore",
+            theq_sdpr_poc.serve_duration_zscore AS "theq_sdpr_poc.serve_duration_zscore",
+            theq_sdpr_poc.service_creation_duration_zscore AS "theq_sdpr_poc.service_creation_duration_zscore",
+            theq_sdpr_poc.waiting_duration_zscore AS "theq_sdpr_poc.waiting_duration_zscore",
+            COUNT(DISTINCT theq_sdpr_poc.client_id ) AS "theq_sdpr_poc.visits_count",
+            COUNT(*) AS "theq_sdpr_poc.services_count",
+            COALESCE(SUM(theq_sdpr_poc.transaction_count ), 0) AS "theq_sdpr_poc.transactions_count",
+            AVG((1.00 * theq_sdpr_poc.service_creation_duration)/(60*60*24) ) AS "theq_sdpr_poc.service_creation_duration_per_visit_average",
+            AVG((1.00 * theq_sdpr_poc.waiting_duration)/(60*60*24) ) AS "theq_sdpr_poc.waiting_duration_per_service_average",
+            AVG((1.00 * theq_sdpr_poc.prep_duration)/(60*60*24) ) AS "theq_sdpr_poc.prep_duration_per_service_average",
+            AVG((1.00 * theq_sdpr_poc.serve_duration)/(60*60*24) ) AS "theq_sdpr_poc.serve_duration_per_service_average",
+            AVG((1.00 * theq_sdpr_poc.hold_duration)/(60*60*24) ) AS "theq_sdpr_poc.hold_duration_per_service_average"
+        FROM
+            "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
+        WHERE
+            ((( "welcome_time" ) >= ((DATEADD(day,-1, DATE_TRUNC(''day'',CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME)) ))) AND
+            ( "welcome_time" ) < ((DATEADD(day,1, DATEADD(day,-1, DATE_TRUNC(''day'',CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME)) ) ))))) AND
+            (TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''),''.'','''') ) IS NOT NULL
+        GROUP BY
+            "update_flag",
+            "theq_sdpr_poc.date",
+            "theq_sdpr_poc.welcome_time",
+            "theq_sdpr_poc.latest_time",
+            "theq_sdpr_poc.office_id",
+            "theq_sdpr_poc.office_name",
+            "theq_sdpr_poc.agent_id",
+            "theq_sdpr_poc.idir",
+            "theq_sdpr_poc.client_id",
+            "theq_sdpr_poc.back_office",
+            "theq_sdpr_poc.channel_sort",
+            "theq_sdpr_poc.channel",
+            "theq_sdpr_poc.counter_type",
+            "theq_sdpr_poc.inaccurate_time",
+            "theq_sdpr_poc.no_wait_visit",
+            "theq_sdpr_poc.program_name",
+            "theq_sdpr_poc.transaction_name",
+            "theq_sdpr_poc.service_count",
+            "theq_sdpr_poc.status",
+            "theq_sdpr_poc.hold_duration_zscore",
+            "theq_sdpr_poc.prep_duration_zscore",
+            "theq_sdpr_poc.serve_duration_zscore",
+            "theq_sdpr_poc.service_creation_duration_zscore",
+            "theq_sdpr_poc.waiting_duration_zscore"
+    ),
+    "update_rows" AS (    
+        SELECT
+            1 AS "update_flag",
+            (DATE("welcome_time")) AS "theq_sdpr_poc.date",
+                (TO_CHAR(DATE_TRUNC(''second'', "welcome_time"), ''YYYY-MM-DD HH24:MI:SS'')) AS "theq_sdpr_poc.welcome_time",
+                (TO_CHAR(DATE_TRUNC(''second'', "latest_time"), ''YYYY-MM-DD HH24:MI:SS'')) AS "theq_sdpr_poc.latest_time",
+            "office_id" AS "theq_sdpr_poc.office_id",
+            "office_name" AS "theq_sdpr_poc.office_name",
+            "agent_id" AS "theq_sdpr_poc.agent_id",
+            "idir" AS "theq_sdpr_poc.idir",
+            "client_id" AS "theq_sdpr_poc.client_id",
+            "back_office" AS "theq_sdpr_poc.back_office",
+            "channel_sort" AS "theq_sdpr_poc.channel_sort",
+            "channel" AS "theq_sdpr_poc.channel",
+            "counter_type" AS "theq_sdpr_poc.counter_type",
+                (CASE WHEN "inaccurate_time" THEN ''Yes'' ELSE ''No'' END) AS "theq_sdpr_poc.inaccurate_time",
+                (CASE WHEN "no_wait_visit" THEN ''Yes'' ELSE ''No'' END) AS "theq_sdpr_poc.no_wait_visit",
+            "program_name" AS "theq_sdpr_poc.program_name",
+            "transaction_name" AS "theq_sdpr_poc.transaction_name",
+            "service_count" AS "theq_sdpr_poc.service_count",
+            COALESCE(theq_sdpr_poc.status, ''Open Ticket'') AS "theq_sdpr_poc.status",
+            theq_sdpr_poc.hold_duration_zscore AS "theq_sdpr_poc.hold_duration_zscore",
+            theq_sdpr_poc.prep_duration_zscore AS "theq_sdpr_poc.prep_duration_zscore",
+            theq_sdpr_poc.serve_duration_zscore AS "theq_sdpr_poc.serve_duration_zscore",
+            theq_sdpr_poc.service_creation_duration_zscore AS "theq_sdpr_poc.service_creation_duration_zscore",
+            theq_sdpr_poc.waiting_duration_zscore AS "theq_sdpr_poc.waiting_duration_zscore",
+            COUNT(DISTINCT theq_sdpr_poc.client_id ) AS "theq_sdpr_poc.visits_count",
+            COUNT(*) AS "theq_sdpr_poc.services_count",
+            COALESCE(SUM(theq_sdpr_poc.transaction_count ), 0) AS "theq_sdpr_poc.transactions_count",
+            AVG((1.00 * theq_sdpr_poc.service_creation_duration)/(60*60*24) ) AS "theq_sdpr_poc.service_creation_duration_per_visit_average",
+            AVG((1.00 * theq_sdpr_poc.waiting_duration)/(60*60*24) ) AS "theq_sdpr_poc.waiting_duration_per_service_average",
+            AVG((1.00 * theq_sdpr_poc.prep_duration)/(60*60*24) ) AS "theq_sdpr_poc.prep_duration_per_service_average",
+            AVG((1.00 * theq_sdpr_poc.serve_duration)/(60*60*24) ) AS "theq_sdpr_poc.serve_duration_per_service_average",
+            AVG((1.00 * theq_sdpr_poc.hold_duration)/(60*60*24) ) AS "theq_sdpr_poc.hold_duration_per_service_average"
+        FROM
+            "derived"."theq_sdpr_step1" AS "theq_sdpr_poc"
+        WHERE
+            "welcome_time" < DATEADD(day, -1, DATE_TRUNC(''day'', CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME)))
+            AND "latest_time" >= DATEADD(day, -1, DATE_TRUNC(''day'', CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME)))
+            AND "latest_time" < DATEADD(day, 1, DATEADD(day, -1, DATE_TRUNC(''day'', CAST(''2021-11-05T10:59:11.561Z'' AS DATETIME))))
+            AND TRANSLATE(TRANSLATE(theq_sdpr_poc.office_name, '' '', ''_''), ''.'', '''') IS NOT NULL
+        GROUP BY
+            "update_flag",
+            "theq_sdpr_poc.date",
+            "theq_sdpr_poc.welcome_time",
+            "theq_sdpr_poc.latest_time",
+            "theq_sdpr_poc.office_id",
+            "theq_sdpr_poc.office_name",
+            "theq_sdpr_poc.agent_id",
+            "theq_sdpr_poc.idir",
+            "theq_sdpr_poc.client_id",
+            "theq_sdpr_poc.back_office",
+            "theq_sdpr_poc.channel_sort",
+            "theq_sdpr_poc.channel",
+            "theq_sdpr_poc.counter_type",
+            "theq_sdpr_poc.inaccurate_time",
+            "theq_sdpr_poc.no_wait_visit",
+            "theq_sdpr_poc.program_name",
+            "theq_sdpr_poc.transaction_name",
+            "theq_sdpr_poc.service_count",
+            "theq_sdpr_poc.status",
+            "theq_sdpr_poc.hold_duration_zscore",
+            "theq_sdpr_poc.prep_duration_zscore",
+            "theq_sdpr_poc.serve_duration_zscore",
+            "theq_sdpr_poc.service_creation_duration_zscore",
+            "theq_sdpr_poc.waiting_duration_zscore"
+    )
+    SELECT * FROM new_rows UNION SELECT * FROM update_rows
+    ORDER BY
+        "theq_sdpr_poc.welcome_time"
+)

--- a/sfts/redshift_to_s3.py
+++ b/sfts/redshift_to_s3.py
@@ -85,6 +85,8 @@ header = config['header']
 sql_parse_key = \
     False if 'sql_parse_key' not in config else config['sql_parse_key']
 
+delimiter = False if 'delimiter' not in config else config['delimiter']
+
 if 'date_list' in config:
     dates = config['date_list']
 
@@ -297,6 +299,12 @@ if sql_parse_key:
     # pass the keyword_dict to the request query formatter
     request_query = request_query.format(**keyword_dict)
 
+# If there is no delimiter specified in the config file
+# build the delimiter string for the UNLOAD query, else leave it blank
+if delimiter:
+    delimiter_string = "delimiter '{delimiter}'".format(delimiter=delimiter)
+else:
+    delimiter_string = ""
 
 # The UNLOAD query to support S3 loading direct from a Redshift query
 # ref: https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html
@@ -307,6 +315,7 @@ UNLOAD ('{request_query}')
 TO 's3://{bucket}/{source_prefix}/{object_key}_part'
 credentials 'aws_access_key_id={aws_access_key_id};\
 aws_secret_access_key={aws_secret_access_key}'
+{delimiter_string}
 PARALLEL OFF
 {header}
 '''.format(
@@ -316,6 +325,7 @@ PARALLEL OFF
     object_key=object_key,
     aws_access_key_id='{aws_access_key_id}',
     aws_secret_access_key='{aws_secret_access_key}',
+    delimiter_string=delimiter_string,
     header='HEADER' if header else '')
 
 query = log_query.format(


### PR DESCRIPTION
This PR does the following:
1. Adds a config file and DML to generate a daily SDPR feed that includes records that were recently updated but were created on a previous day
2. Adds a config file and DML to generate a hourly SDPR feed that includes records from the start of the day up to the top of the hour that the microservice is run
3. Updates redshift_to_s3.py to support different delimiters that are set in the config, with it defaulting to a | (pipe) if no delimiter is specified

To quickly review the changes:
1. For the daily incremental data, review yesterday's file in [theq_sdpr/daily/Oct2022_incremental_update s3 bucket](https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/theq_sdpr/daily/Oct_2022_incremental_update/&showversions=false) and compare them with the same date file in the [old s3 bucket](https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/theq_sdpr/daily/&showversions=false). You should notice that there is an additional "update_flag" column in the incremental update file, and that the incremental update file should at least contain all of the data that was in the old file. If there were any recently updated data from a previous day, these should appear at the top of the incremental update file, and be highlighted with an "update_flag" column value of 1.
2. For the hourly data, review the files in [theq_sdpr/hourly/Oct2022_incremental_update s3 bucket](https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/theq_sdpr/hourly/Oct_2022_incremental_update/&showversions=false). Look at the files last modified date and check to see that the file doesn't have any data that takes place before the top of that last modified hour

Testing these changes requires some modifications to the existing configs so that there are no affects to the production system:

Log into microservice_ssm
```
awsmfa prod <AWS OTP>
microservice_ssm
```
Navigate to the development branch 
`cd branch/GDXDSD-5053-SDPR-incremental-update/sfts/`

Modify the config.d/[sdpr_last_full_day_incremental.json](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5053-SDPR-incremental-update/sfts/config.d/sdpr_last_full_day_incremental.json) "directory" value to be written to a different s3 bucket, ex.
`  "directory": "doug_test",`

Manually run the microservice and inspect the generated file to test the SDPR daily incremental change. It should contain an "update_flag" column and should only include records created yesterday, or records from previous days that were updated yesterday
`pipenv run python redshift_to_s3.py -c config.d/sdpr_last_full_day_incremental.json `

Modify the config.d/[sdpr_last_full_day_incremental.json](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5053-SDPR-incremental-update/sfts/config.d/sdpr_last_full_day_incremental.json) "directory" value to be written to a different s3 bucket, ex.
` "directory": "doug_test", `

Manually run the microservice and inspect the generated file to test the SDPR hourly change. It should only contain data that was created today up to the top of the hour that the microservice was run
`pipenv run python redshift_to_s3.py -c config.d/sdpr_hourly.json  `

Modify an unrelated config file "directory" value to be written to a different s3 bucket. ex for config.d/[pmrp_qdata_daily.json](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5053-SDPR-incremental-update/sfts/config.d/pmrp_qdata_daily.json) 
` "directory": "doug_test",  `

Manually run the microservice and inspect the generated file to test the delimiter change. The file should be | (pipe) delimited
`pipenv run python redshift_to_s3.py -c config.d/pmrp_qdata_daily.json`

Undo the changes you made for testing with the following command
`git restore .`