### PR TITLE
Correct date range that google search covers

### DIFF
--- a/google-api/README.md
+++ b/google-api/README.md
@@ -13,7 +13,7 @@ The `google_search.py` script automates the loading of Google Search data into S
 
 The Google Search Console API documentation is here: https://developers.google.com/webmaster-tools/search-console-api-original. The latest data available from the Google Search API is from two days ago (relative to "_now_"). The Search Console API provides programmatic access to most of the functionality of Google Search Console.
 
-The Google Search Console is here: https://search.google.com/search-console. This console helps to visually identify which Properties you have verified owner access to and allows manual querying of slightly more recent data than the API provides programmatic access to (you can see data from 1 day ago, instead of from 3 days ago).
+The Google Search Console is here: https://search.google.com/search-console. This console helps to visually identify which Properties you have verified owner access to and allows manual querying of slightly more recent data than the API provides programmatic access to (you can see data from 1 day ago, instead of from 2 days ago).
 
 To illustrate: on a Friday, the Search Console web interface would show search data on your property from a maximum range of search data from 18 months ago up until Thursday. However, the Search Console API would only be able to collect a maximum range of search data from 18 months ago up until Wednesday.
 


### PR DESCRIPTION
An update to date range was made in the readme for google_search, this was incorrect and we need to change the date from 3 back to 2 to accurately represent the actions in the script. 