### PR TITLE
Gdxdsd 5830 fix s3 to sfts microservice report 20230426

### DIFF
--- a/s3_to_sfts/s3_to_sfts.py
+++ b/s3_to_sfts/s3_to_sfts.py
@@ -150,31 +150,37 @@ def report(data):
         f'elapsing: {yvr_dt_end - yvr_dt_start}.')
     print(f'\nItems to process: {data["objects"]}')
     print(f'Objects successfully processed to sfts: {len(data["sfts_processed_list"])}')
-    print(f'Objects unsuccessfully processed to sfts: {len(data["sfts_not_processed_list"])}')
+    print(f'Objects that failed to process to sfts: {len(data["sfts_not_processed_list"])}')
     print(f'Objects successfully processed to s3: {len(data["s3_processed_list"])}')
-    print(f'Objects unsuccessfully processed to s3: {len(data["s3_not_processed_list"])}')
+    print(f'Objects that failed to process to s3: {len(data["s3_not_processed_list"])}')
 
     # Print all objects processed to sfts 
     if data['sfts_processed_list']:
-        print(f'\nObjects processed to sfts:\n')  
+        print(f'\nList of objects processed to sfts:\n')  
         for i, item in enumerate(data['sfts_processed_list'], 1):
             print(f"{i}: {item}")
 
     # Print all objects not processed to sfts 
     if data['sfts_not_processed_list']:
-        print(f'\nObjects not processed to sfts:\n')
+        print(f'\nList of objects that failed to process to sfts:\n')
         for i, item in enumerate(data['sfts_not_processed_list'], 1):
             print(f"{i}: {item}")
-    
+   
+    s3_process_type = ''
+    if data['s3_processed_good']:
+        s3_process_type = 'good'
+    else:
+        s3_process_type = 'bad'
+ 
     # Print all objects coppied to s3 archived
     if data['s3_processed_list']:
-        print(f'\nObjects coppied to S3 archives:\n')  
+        print(f'\nList of objects copied to S3 {s3_process_type} archives:\n')  
         for i, item in enumerate(data['s3_processed_list'], 1):
             print(f"{i}: {item}")
 
     # Print all objects not coppied to s3 archives 
     if data['s3_not_processed_list']:
-        print(f'\nObjects not coppied to S3 archives:\n')
+        print(f'\nList of objects that failed to copy to S3 {s3_process_type} archives:\n')
         for i, item in enumerate(data['s3_not_processed_list'], 1):
             print(f"{i}: {item}")
 
@@ -183,6 +189,7 @@ def report(data):
 report_stats = {
     'objects':0,
     'objects_to_sfts':False,
+    's3_processed_good':False,
     's3_processed_list':[], 
     's3_not_processed_list':[],
     'sfts_processed_list':[],
@@ -285,6 +292,7 @@ for obj in objects_to_process:
     # currently it's all based on whether or not the XFER call returned 0 or 1
     if xfer_proc:
         outfile = f"{archive}/good/{archive_key}"
+        report_stats['s3_processed_good'] = True
     else:
         outfile = f"{archive}/bad/{archive_key}"
     try:

--- a/s3_to_sfts/s3_to_sfts.py
+++ b/s3_to_sfts/s3_to_sfts.py
@@ -271,10 +271,7 @@ except subprocess.CalledProcessError:
 else:
     report_stats['objects_to_sfts'] = True
     for obj in objects_to_process:
-        report_stats['sfts_processed_list'].append(obj.key.replace(
-            f'{source}/{source_client}/{source_directory}', 
-            f'{sfts_path}', 
-            1))
+        report_stats['sfts_processed_list'].append(obj.key)
 
 # copy the processed files to their outfile archive path
 for obj in objects_to_process:
@@ -300,7 +297,7 @@ for obj in objects_to_process:
         report_stats['s3_not_processed_list'].append(obj.key)
     else:
         logger.info('copied %s to %s', obj.key, outfile)
-        report_stats['s3_processed_list'].append(outfile)
+        report_stats['s3_processed_list'].append(obj.key)
 
 
 # Remove the temporary local files used to transfer

--- a/s3_to_sfts/s3_to_sfts.py
+++ b/s3_to_sfts/s3_to_sfts.py
@@ -149,20 +149,20 @@ def report(data):
         f'ended at: {yvr_dt_end.strftime("%Y-%m-%d %H:%M:%S%z (%Z)")}, '
         f'elapsing: {yvr_dt_end - yvr_dt_start}.')
     print(f'\nItems to process: {data["objects"]}')
-    print(f'Objects successfully processed to s3: {data["objects_processed"]}')
-    print(f'Objects unsuccessfully processed to s3: {data["objects_not_processed"]}')
-    print(f'Objects successfully processed to sfts: {len(data["s3_good_list"])}')
+    print(f'Objects successfully processed to s3: {len(data["s3_processed_list"])}')
+    print(f'Objects unsuccessfully processed to s3: {len(data["s3_not_processed_list"])}')
+    print(f'FIX: Objects successfully processed to sfts: {len(data["s3_processed_list"])}')
 
-    # Print all objects loaded into s3/good
-    if data['s3_good_list']:
-        print(f'\nObjects loaded to S3 /good:')  
-        for i, item in enumerate(data['s3_good_list'], 1):
+    # Print all objects coppied to s3 archived
+    if data['s3_processed_list']:
+        print(f'\nObjects coppied to S3 archives:')  
+        for i, item in enumerate(data['s3_processed_list'], 1):
             print(f"\n{i}: {item}")
 
-    # Print all objects loaded into s3/bad
-    if data['s3_bad_list']:
-        print(f'\nObjects loaded to S3 /bad:')
-        for i, item in enumerate(data['s3_bad_list'], 1):
+    # Print all objects not coppied to s3 archives 
+    if data['s3_not_processed_list']:
+        print(f'\nObjects not coppied to S3 archives:')
+        for i, item in enumerate(data['s3_not_processed_list'], 1):
             print(f"\n{i}: {item}")
 
 
@@ -173,8 +173,8 @@ report_stats = {
     'objects_not_processed':0,
     'objects_to_sfts':False,
     'objects_list':[],
-    's3_good_list':[], 
-    's3_bad_list':[],
+    's3_processed_list':[], 
+    's3_not_processed_list':[],
     'sfts_good_list':[],
     'sfts_bad_list':[]
 }
@@ -279,12 +279,12 @@ for obj in objects_to_process:
             Key=outfile)
     except ClientError:
         logger.exception('Exception copying object %s', obj.key)
-        report_stats['s3_bad_list'].append(outfile)
+        report_stats['s3_not_processed_list'].append(outfile)
         report_stats['objects_not_processed'] += 1
     else:
         logger.info('copied %s to %s', obj.key, outfile)
         report_stats['objects_processed'] += 1
-        report_stats['s3_good_list'].append(outfile)
+        report_stats['s3_processed_list'].append(outfile)
 
 
 # Remove the temporary local files used to transfer

--- a/s3_to_sfts/s3_to_sfts.py
+++ b/s3_to_sfts/s3_to_sfts.py
@@ -156,27 +156,27 @@ def report(data):
 
     # Print all objects processed to sfts 
     if data['sfts_processed_list']:
-        print(f'\nObjects processed to sfts:')  
+        print(f'\nObjects processed to sfts:\n')  
         for i, item in enumerate(data['sfts_processed_list'], 1):
-            print(f"\n{i}: {item}")
+            print(f"{i}: {item}")
 
     # Print all objects not processed to sfts 
     if data['sfts_not_processed_list']:
-        print(f'\nObjects not processed to sfts:')
+        print(f'\nObjects not processed to sfts:\n')
         for i, item in enumerate(data['sfts_not_processed_list'], 1):
-            print(f"\n{i}: {item}")
+            print(f"{i}: {item}")
     
     # Print all objects coppied to s3 archived
     if data['s3_processed_list']:
-        print(f'\nObjects coppied to S3 archives:')  
+        print(f'\nObjects coppied to S3 archives:\n')  
         for i, item in enumerate(data['s3_processed_list'], 1):
-            print(f"\n{i}: {item}")
+            print(f"{i}: {item}")
 
     # Print all objects not coppied to s3 archives 
     if data['s3_not_processed_list']:
-        print(f'\nObjects not coppied to S3 archives:')
+        print(f'\nObjects not coppied to S3 archives:\n')
         for i, item in enumerate(data['s3_not_processed_list'], 1):
-            print(f"\n{i}: {item}")
+            print(f"{i}: {item}")
 
 
 # Reporting variables. Accumulates as the the loop below is traversed
@@ -271,7 +271,10 @@ except subprocess.CalledProcessError:
 else:
     report_stats['objects_to_sfts'] = True
     for obj in objects_to_process:
-        report_stats['sfts_processed_list'].append(obj.key)
+        report_stats['sfts_processed_list'].append(obj.key.replace(
+            f'{source}/{source_client}/{source_directory}', 
+            f'{sfts_path}', 
+            1))
 
 # copy the processed files to their outfile archive path
 for obj in objects_to_process:
@@ -294,7 +297,7 @@ for obj in objects_to_process:
             Key=outfile)
     except ClientError:
         logger.exception('Exception copying object %s', obj.key)
-        report_stats['s3_not_processed_list'].append(outfile)
+        report_stats['s3_not_processed_list'].append(obj.key)
     else:
         logger.info('copied %s to %s', obj.key, outfile)
         report_stats['s3_processed_list'].append(outfile)


### PR DESCRIPTION
This PR does the following:

Fixes an error in the S3 to SFTS microservice report that lists objects under the wrong heading

Background for testing:

The S3 to SFTS microservice searches one client's S3 folder for unprocessed file(s) with a specific file prefix and uploads them to a location in SFTS. All of these locations are specified in a config file that is given to the microservice when it's executed. The config can also optionally append a file extension to the object in S3. The object is also copied to a processed S3 folder, which final location depends on whether the upload to SFTS was successful.

For testing purposes, we will  be using separate configs that are not included in the repository's files. This allows the tests to manipulate the files through S3 and SFTS without affecting the production invironment. These configs can be found attached to the ticket.

Testing instructions:
1. Log into the ec2 instance through the following commands
```
awsmfa prod <AWS OTP>
microservice_ssm
/home/microservice/branch/GDXDSD-5830-fix-s3-to-sfts-microservice-report-20230426/s3_to_sfts
```
2. Run the following command to test a successful load to SFTS.
```
pipenv run python s3_to_sfts.py -c config.d/GDXDSD-5830-success.json
```
```
Report: s3_to_sfts.py


Config: config.d/GDXDSD-5830-success.json


Microservice started at: 2023-05-09 16:17:09-0700 (PDT), ended at: 2023-05-09 16:17:15-0700 (PDT), elapsing: 0:00:05.631982.


Items to process: 2
Objects successfully processed to sfts: 2
Objects that failed to process to sfts: 0
Objects successfully processed to s3: 2
Objects that failed to process to s3: 0


List of objects processed to sfts:


1: client/doug_test/GDXDSD-5830/data_client/success/GDXDSD-5830-success-2.txt
2: client/doug_test/GDXDSD-5830/data_client/success/GDXDSD-5830-success.txt


List of objects copied to S3 good archives:


1: client/doug_test/GDXDSD-5830/data_client/success/GDXDSD-5830-success-2.txt
2: client/doug_test/GDXDSD-5830/data_client/success/GDXDSD-5830-success.txt 
```
3. Check SFTS to see if the files were successfully uploaded: https://filetransfer.gov.bc.ca/human.aspx?r=1880945809&arg06=954283670&arg12=filelist
4. Check to see if the file appear in the s3 processed good bucket: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5830/data-sfts_client/success/&showversions=false
5. Run the following command to test a unsuccessful load to SFTS.
```
pipenv run python s3_to_sfts.py -c config.d/GDXDSD-5830-failure.json
```
```
Report: s3_to_sfts.py


Config: config.d/GDXDSD-5830-failure.json
*** ATTN: A failure occured ***


Microservice started at: 2023-05-09 16:17:22-0700 (PDT), ended at: 2023-05-09 16:17:24-0700 (PDT), elapsing: 0:00:01.998279.


Items to process: 2
Objects successfully processed to sfts: 0
Objects that failed to process to sfts: 2
Objects successfully processed to s3: 2
Objects that failed to process to s3: 0


List of objects that failed to process to sfts:


1: client/doug_test/GDXDSD-5830/data_client/failure/GDXDSD-5830-failure-2.txt
2: client/doug_test/GDXDSD-5830/data_client/failure/GDXDSD-5830-failure.txt


List of objects copied to S3 bad archives:


1: client/doug_test/GDXDSD-5830/data_client/failure/GDXDSD-5830-failure-2.txt
2: client/doug_test/GDXDSD-5830/data_client/failure/GDXDSD-5830-failure.txt 
```
6. Check to see if the file appear in the s3 processed bad bucket: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/bad/client/doug_test/GDXDSD-5830/data-sfts_client/failure/&showversions=false