### PR TITLE
Changed client folder s3 location for the SBC SDPR data feeds

### DIFF
--- a/redshift_to_s3/config.d/sbc-sdpr_historical.json
+++ b/redshift_to_s3/config.d/sbc-sdpr_historical.json
@@ -2,7 +2,7 @@
   "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
   "storage": "client",
   "archive": "processed",
-  "directory": "theq_sdprabi/sbc-sdpr_historical/v02-Mar_2023_new_columns",
+  "directory": "theq_sdpr/sbc-sdpr_historical/v03-May_2023_folder_change",
   "object_prefix": "sbc-sdpr_historical",
   "dml": "sbc-sdpr_historical.sql",
   "header": true,

--- a/redshift_to_s3/config.d/sbc-sdpr_last_full_day_incremental.json
+++ b/redshift_to_s3/config.d/sbc-sdpr_last_full_day_incremental.json
@@ -2,7 +2,7 @@
   "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
   "storage": "client",
   "archive": "processed",
-  "directory": "theq_sdprabi/sbc-sdpr_daily-incremental/v02-Mar_2023_new_columns",
+  "directory": "theq_sdpr/sbc-sdpr_daily-incremental/v03-May_2023_folder_change",
   "object_prefix": "sbc-sdpr_daily-incremental",
   "dml": "sbc-sdpr_last_full_day_incremental.sql",
   "header": true,


### PR DESCRIPTION
This PR does the following:
Changes the client folder S3 location, and version sub-folders for the [sbc-sdpr_historical.json](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5869-change-sbc-sdpr-data-export-client-folder-in-s3/redshift_to_s3/config.d/sbc-sdpr_historical.json) and [sbc-sdpr_last_full_day_incremental.json](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5869-change-sbc-sdpr-data-export-client-folder-in-s3/redshift_to_s3/config.d/sbc-sdpr_last_full_day_incremental.json) data feeds.

Background for the review:
The Redshift to S3 microservice exports a data file based off of a dml file that is specified in a config that is provided when the job is ran. The config also specifies: what folder in S3 that the file is exported to, the delimiter used in the data file, and the file extension. 
The storage location is built off the config values for: [bucket]/[storage]/[directory]

Review instructions:

1. Look at [sbc-sdpr_historical.json](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5869-change-sbc-sdpr-data-export-client-folder-in-s3/redshift_to_s3/config.d/sbc-sdpr_historical.json) and make sure that the values can build the S3 URI s3://sp-ca-bc-gov-131565110619-12-microservices/client/theq_sdpr/sbc-sdpr_historical/v03-May_2023_folder_change/
2. Look at [sbc-sdpr_last_full_day_incremental.json](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5869-change-sbc-sdpr-data-export-client-folder-in-s3/redshift_to_s3/config.d/sbc-sdpr_last_full_day_incremental.json) and make sure that the values can build the S3 URI s3://sp-ca-bc-gov-131565110619-12-microservices/client/theq_sdpr/sbc-sdpr_daily-incremental/v03-May_2023_folder_change/
