### PR TITLE
Gdxdsd 5682 fix redshift to s3 mishandling unspecified subfolders

### DIFF
--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -493,7 +493,7 @@ with psycopg2.connect(conn_string) as conn:
                     logger.exception('Exception copying from s3://%s/%s', bucket, copy_from_prefix)
                     logger.exception('to s3://%s/%s', bucket, copy_to_prefix)
                     report_stats['unstored_objects'] += 1
-                    report_stats['unstored_objects_list'].append(copy_from_prefix)
+                    report_stats['unstored_objects_list'].append(copy_to_prefix)
                     
                     logger.info('Copying to s3 /bad ...')
                     client.copy_object(
@@ -502,7 +502,7 @@ with psycopg2.connect(conn_string) as conn:
                         Key=copy_bad_prefix)
                     logger.info('Copied from s3://%s/%s', bucket, copy_from_prefix)
                     logger.info('Copied to s3://%s/%s', bucket, copy_bad_prefix)
-                    report_stats['bad_objects_list'].append(copy_from_prefix)
+                    report_stats['bad_objects_list'].append(copy_bad_prefix)
                     report_stats['bad_objects'] += 1
                     
                     report(report_stats)
@@ -511,7 +511,7 @@ with psycopg2.connect(conn_string) as conn:
                     logger.info('Copied from s3://%s/%s', bucket, copy_from_prefix)
                     logger.info('Copied to s3://%s/%s', bucket, copy_to_prefix)
                     report_stats['stored_objects'] += 1
-                    report_stats['stored_objects_list'].append(copy_from_prefix)
+                    report_stats['stored_objects_list'].append(copy_to_prefix)
                     
                     logger.info('Copying to s3 /good ...')
                     client.copy_object(
@@ -521,7 +521,7 @@ with psycopg2.connect(conn_string) as conn:
                     logger.info('Copied from s3://%s/%s', bucket, copy_from_prefix)
                     logger.info('Copied to s3://%s/%s', bucket, copy_good_prefix)
                     report_stats['good_objects'] += 1
-                    report_stats['good_objects_list'].append(copy_from_prefix)
+                    report_stats['good_objects_list'].append(copy_good_prefix)
 
             report(report_stats)
             clean_exit(0,'Finished succesfully.')

--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -267,7 +267,7 @@ def report(data):
         print(f'\nList of objects stored to S3 /client:')
         if data['stored_objects_list']:
             for i, item in enumerate(data['stored_objects_list'], 1):
-                print(f"{i}: {storage_prefix}/{item}")
+                print(f"{i}: {item}")
 
     # Print all objects not loaded into s3/client
     if data["unstored_objects"]:
@@ -275,7 +275,7 @@ def report(data):
         print(f'\nList of objects not stored to S3 /client:')
         if data['unstored_objects_list']:
             for i, item in enumerate(data['unstored_objects_list'], 1):
-                print(f"{i}: {storage_prefix}/{item}")
+                print(f"{i}: {item}")
 
     print(f'\n\nObjects to process: {data["unprocessed_objects"]}')
 
@@ -285,7 +285,7 @@ def report(data):
         print(f'\nList of objects processed to S3 /good:')
         if data['good_objects_list']:
             for i, item in enumerate(data['good_objects_list'], 1):
-                print(f"{i}: {good_prefix}/{item}")
+                print(f"{i}: {item}")
 
     # Print all objects loaded into s3/bad
     if data["bad_objects"]:
@@ -293,7 +293,7 @@ def report(data):
         print(f'\nList of objects processed to S3 /bad:')
         if data['bad_objects_list']:
             for i, item in enumerate(data['bad_objects_list'], 1):
-                print(f"{i}: {bad_prefix}/{item}")
+                print(f"{i}: {item}")
 
 # Reporting variables. Accumulates as the the loop below is traversed
 report_stats = {
@@ -411,9 +411,10 @@ def get_unprocessed_objects():
     objects_to_process = []
     for object_summary in res_bucket.objects.filter(Prefix=f'{batch_prefix}/'): # batch_prefix may need a trailing /
         key = object_summary.key
+
         filename = key[key.rfind('/')+1:]  # get the filename (after the last '/')
-        goodfile = f"{good_prefix}/{filename}"
-        badfile = f"{bad_prefix}/{filename}"
+        goodfile = f"{good_prefix}/{key}"
+        badfile = f"{bad_prefix}/{key}"
 
         def is_processed():
             '''Check to see if the file has been processed already'''
@@ -460,7 +461,7 @@ with psycopg2.connect(conn_string) as conn:
         else:
             logger.info(
                 'UNLOAD successful. Object prefix is %s/%s/%s',
-                bucket, storage_prefix, object_key)
+                bucket, batch_prefix, object_key)
             report_stats['successful_unloads'] += 1
             report_stats['successful_unloads_list'].append(object_key)
 
@@ -471,20 +472,20 @@ with psycopg2.connect(conn_string) as conn:
                 filename = key[key.rfind('/')+1:]  # get the filename (after the last '/')
 
                 # final paths that include the filenames
-                copy_good_prefix = f"{good_prefix}/{filename}"
-                copy_bad_prefix = f"{bad_prefix}/{filename}"
-                copy_from_prefix = f"{batch_prefix}/{filename}"
+                copy_from_prefix = f"{key}" # the same as the initial object prefix
+                copy_to_prefix = key.replace(f'{archive}/batch/', '', 1) # insert the batch path to the start of the existing prefix
+                copy_good_prefix = key.replace(f'{archive}/batch/', f'{archive}/good/', 1) # insert the good path to the start of the existing prefix
+                copy_bad_prefix = key.replace(f'{archive}/batch/', f'{archive}/bad/', 1) # insert the bad path to the start of the existing prefix
+
                 if 'extension' in config:
                     # if an extension was set in the config, add it to the end of the file
                     extension = config['extension']
-                    filename_with_extension = f"{filename}{extension}"
+                    copy_to_prefix = f"{copy_to_prefix}{extension}"
                     logger.info('File extension set in %s as "%s"', config_file, extension)
                 else:
-                    filename_with_extension = filename
                     logger.info('File extension not set in %s', config_file)
                 try:
                     # final storage path that includes the filename and optional extension
-                    copy_to_prefix = f"{storage_prefix}/{filename_with_extension}"
                     logger.info('Copying to s3 /client ...')
                     client.copy_object(
                         Bucket=bucket,
@@ -494,7 +495,7 @@ with psycopg2.connect(conn_string) as conn:
                     logger.exception('Exception copying from s3://%s/%s', bucket, copy_from_prefix)
                     logger.exception('to s3://%s/%s', bucket, copy_to_prefix)
                     report_stats['unstored_objects'] += 1
-                    report_stats['unstored_objects_list'].append(filename_with_extension)
+                    report_stats['unstored_objects_list'].append(copy_from_prefix)
                     
                     logger.info('Copying to s3 /bad ...')
                     client.copy_object(
@@ -503,7 +504,7 @@ with psycopg2.connect(conn_string) as conn:
                         Key=copy_bad_prefix)
                     logger.info('Copied from s3://%s/%s', bucket, copy_from_prefix)
                     logger.info('Copied to s3://%s/%s', bucket, copy_bad_prefix)
-                    report_stats['bad_objects_list'].append(filename)
+                    report_stats['bad_objects_list'].append(copy_from_prefix)
                     report_stats['bad_objects'] += 1
                     
                     report(report_stats)
@@ -512,7 +513,7 @@ with psycopg2.connect(conn_string) as conn:
                     logger.info('Copied from s3://%s/%s', bucket, copy_from_prefix)
                     logger.info('Copied to s3://%s/%s', bucket, copy_to_prefix)
                     report_stats['stored_objects'] += 1
-                    report_stats['stored_objects_list'].append(filename_with_extension)
+                    report_stats['stored_objects_list'].append(copy_from_prefix)
                     
                     logger.info('Copying to s3 /good ...')
                     client.copy_object(
@@ -522,7 +523,7 @@ with psycopg2.connect(conn_string) as conn:
                     logger.info('Copied from s3://%s/%s', bucket, copy_from_prefix)
                     logger.info('Copied to s3://%s/%s', bucket, copy_good_prefix)
                     report_stats['good_objects'] += 1
-                    report_stats['good_objects_list'].append(filename)
+                    report_stats['good_objects_list'].append(copy_from_prefix)
 
             report(report_stats)
             clean_exit(0,'Finished succesfully.')

--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -469,7 +469,6 @@ with psycopg2.connect(conn_string) as conn:
             objects = get_unprocessed_objects()
             for object in objects:
                 key = object.key
-                filename = key[key.rfind('/')+1:]  # get the filename (after the last '/')
 
                 # final paths that include the filenames
                 copy_from_prefix = f"{key}" # the same as the initial object prefix
@@ -485,7 +484,6 @@ with psycopg2.connect(conn_string) as conn:
                 else:
                     logger.info('File extension not set in %s', config_file)
                 try:
-                    # final storage path that includes the filename and optional extension
                     logger.info('Copying to s3 /client ...')
                     client.copy_object(
                         Bucket=bucket,


### PR DESCRIPTION
This PR does the following:

1. Fixes bug in redshift_to_s3.py so that S3 object paths are built so that all unspecified subfolders are retained.
2. Rewrites redshift_to_s3.py path building logic so that it is similar to [s3_to_sfts.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/main/s3_to_sfts/s3_to_sfts.py)

There is the possibility with the current redshift_to_s3.py script that objects in subfolders that are not specified in the job's config file will be copied to the wrong client/good/bad paths in S3. This is because the way the S3 object prefixes were built searched for the filename after the last / (slash) and appended it to the prefixes built from the values in the config. If the subfolders were not specified in the config, they were lost in this process.

This scenario is likely to never happen but could potentially occur if something external causes the microservice to fail while it's trying to process the objects through S3. This would happen if the objects created by this failed run are not cleaned up, and this error isn't caught before the next time the microservice is ran.

The test config and S3 buckets are set up in a way to mimic the scenario where an object was successfully unloaded to the batch folder but failed to copy to the client and archive folders. 

Please note that a config file was modified so that the tests can run. The modified config will be added to the ticket.

Testing instructions:
1. Review [redshift_to_s3.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5682-fix-redshift-to-s3-mishandling-unspecified-subfolders/redshift_to_s3/redshift_to_s3.py)
2. Log into the ec2 instance through the following commands
```
awsmfa prod <AWS OTP>
microservice_ssm
cd /home/microservice/branch/GDXDSD-5682-fix-redshift-to-s3-mishandling-unspecified-subfolders/redshift_to_s3/
```
3. Run the following command and compare its output to what's expected
```
pipenv run python redshift_to_s3.py -c config.d/GDXDSD-5682.json
```
```
***The microservice ran successfully***

Report: redshift_to_s3.py

Config: config.d/GDXDSD-5682.json

DML: pmrp_qdata_daily.sql

Microservice started at: 2023-06-20 10:12:19-0700 (PDT), ended at: 2023-06-20 10:12:29-0700 (PDT), elapsing: 0:00:09.344694.


Objects loaded to S3 /batch: 1/1
Objects successfully loaded to S3 /batch: 1

List of objects successfully loaded to S3 /batch
1. processed/batch/client/doug_test/GDXDSD-5682/pmrp_qdata_20230620T171219


Objects to store: 2
Objects stored to s3 /client: 2

List of objects stored to S3 /client:
1: client/doug_test/GDXDSD-5682/extra files/pmrp_qdata_20230515T023002_part000
2: client/doug_test/GDXDSD-5682/pmrp_qdata_20230620T171219_part000


Objects to process: 2
Objects processed to s3 /good: 2

List of objects processed to S3 /good:
1: processed/good/client/doug_test/GDXDSD-5682/extra files/pmrp_qdata_20230515T023002_part000
2: processed/good/client/doug_test/GDXDSD-5682/pmrp_qdata_20230620T171219_part000
```
4. Check to see if the file appear in the s3 processed batch bucket (its subfolder has already been populated): https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?prefix=processed%2Fbatch%2Fclient%2Fdoug_test%2FGDXDSD-5682%2F&region=ca-central-1&showversions=false#
5. Check to see if the files appear in the s3 client bucket and its subfolders: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5682/&showversions=false
6. Check to see if the files appear in the s3 processed good bucket and its subfolders: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5682/&showversions=false