### PR TITLE
Gdxdsd 6025 create test script for microservice iam key rotation

### DIFF
--- a/s3_to_redshift/config.d/test.microservice_iam_key_rotation.json
+++ b/s3_to_redshift/config.d/test.microservice_iam_key_rotation.json
@@ -1,0 +1,14 @@
+{
+  "bucket": "sp-ca-bc-gov-131565110619-12-microservices",
+  "source": "client",
+  "destination": "processed",
+  "directory": "test_microservice-iam-key",
+  "doc": "GDXDSD-.*.csv",
+  "dbtable": "test.microservice_iam_key_rotation",
+  "column_count": 1,
+  "columns": [
+	"date_of_test"
+  ],
+  "delim": "," ,
+  "truncate": true
+}

--- a/s3_to_redshift/config.d/test.microservice_iam_key_rotation.json
+++ b/s3_to_redshift/config.d/test.microservice_iam_key_rotation.json
@@ -7,7 +7,7 @@
   "dbtable": "test.microservice_iam_key_rotation",
   "column_count": 1,
   "columns": [
-	"date_of_test"
+	"verification_phrase"
   ],
   "delim": "," ,
   "truncate": true

--- a/s3_to_redshift/ddl/test.microservice_iam_key_rotation.sql
+++ b/s3_to_redshift/ddl/test.microservice_iam_key_rotation.sql
@@ -1,0 +1,6 @@
+CREATE TABLE IF NOT EXISTS test.microservice_iam_key_rotation
+( 
+  "date_of_test" VARCHAR(20) ENCODE ZSTD,
+);
+
+GRANT SELECT ON test.microservice_iam_key_rotation TO "looker";

--- a/s3_to_redshift/ddl/test.microservice_iam_key_rotation.sql
+++ b/s3_to_redshift/ddl/test.microservice_iam_key_rotation.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS test.microservice_iam_key_rotation
 ( 
-  "date_of_test" VARCHAR(20) ENCODE ZSTD,
+  "date_of_test" VARCHAR(20) ENCODE ZSTD
 );
 
 GRANT SELECT ON test.microservice_iam_key_rotation TO "looker";

--- a/s3_to_redshift/ddl/test.microservice_iam_key_rotation.sql
+++ b/s3_to_redshift/ddl/test.microservice_iam_key_rotation.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS test.microservice_iam_key_rotation
 ( 
-  "date_of_test" VARCHAR(20) ENCODE ZSTD
+  "verification_phrase" VARCHAR(20) ENCODE ZSTD
 );
 
 GRANT SELECT ON test.microservice_iam_key_rotation TO "looker";


### PR DESCRIPTION
This PR does the following:
1. Adds a DDL file that can be used to create a test table in Redshift. This can then be used as a destination for the test s3_to_redshift job that will be ran to verify microservice's IAM key rotation was successful.
2. Adds a config file that can be used during the test s3_to_redshift job, that contains where in S3 to look for the CSV, the expected structure of the CSV, and where in Redshift to insert the data in the CSV.

Testing instructions:
1. Review the test DDL file: [test.microservice_iam_key_rotation.sql](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-6025-create-test-script-for-microservice-IAM-key-rotation/s3_to_redshift/ddl/test.microservice_iam_key_rotation.sql)
2. Review the test config file: [test.microservice_iam_key_rotation.json](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-6025-create-test-script-for-microservice-IAM-key-rotation/s3_to_redshift/config.d/test.microservice_iam_key_rotation.json)
3. Log into the ec2 instance through the following commands
```
awsmfa prod <AWS OTP>
microservice_ssm
/home/microservice/branch/GDXDSD-6025-create-test-script-for-microservice-IAM-key-rotation/s3_to_redshift
```
4. Login to Redshift:
```
microservice_rs
```
5. Execute the following SQL query and take note of the current verification_phrase:
```
SELECT * FROM test.microservice_iam_key_rotation;
```
6. Logout of Redshift:
```
\q
```
7. Download a copy of [GDXDSD-6025.csv](https://s3.console.aws.amazon.com/s3/object/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/test_microservice-iam-key/GDXDSD-6025.csv)
8. Replace the verification_phrase value with a value that is different from the current phrase (that is smaller than 20 characters), rename the file to something unique that keeps the 'GDXDSD-' beginning and the '.csv' ending, and re-upload it into the client folder [test_microservice-iam-key/](https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/test_microservice-iam-key/&showversions=false)
9. Run the following command and compare its output to what's expected:
```
pipenv run python s3_to_redshift.py config.d/test.microservice_iam_key_rotation.json 
```
```
Report: s3_to_redshift.py

Config: config.d/test.microservice_iam_key_rotation.json

Microservice started at: 2023-07-27 10:59:58-0700 (PDT), ended at: 2023-07-27 11:00:11-0700 (PDT), elapsing: 0:00:12.961424.

Objects to process: 1
Objects successfully processed: 1
Objects that failed to process: 0
Objects output to 'processed/good': 1
Objects output to 'processed/bad': 0
Objects loaded to Redshift: 1
Empty Objects: 0


List of objects successfully fully ingested from S3, processed, loaded to S3 ('good'), and copied to Redshift:
1: client/test_microservice-iam-key/GDXDSD-6025.csv
```
10. Check to see if the file appears in the s3 processed batch bucket: [test_microservice-iam-key/](https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/batch/client/test_microservice-iam-key/&showversions=false)
11. Check to see if the file appear in the s3 processed good bucket: [test_microservice-iam-key/](https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/test_microservice-iam-key/&showversions=false)
12. Re-login to Redshift:
```
microservice_rs
```
13. Re-execute the SQL query to check if your verification_phrase appears:
```
SELECT * FROM test.microservice_iam_key_rotation;
```
14. Logout of Redshift:
```
\q
```