### PR TITLE
Gdxdsd 5611 add quotes around text option to redshift to s3

### DIFF
--- a/redshift_to_s3/README.md
+++ b/redshift_to_s3/README.md
@@ -80,7 +80,9 @@ The structure of the config file should resemble the following:
   "end_date": String,
   "date_list": String,
   "extension": String,
-  "delimiter": String
+  "escape": Boolean,
+  "delimiter": String,
+  "addquotes": Boolean
 }
 ```
 
@@ -109,7 +111,9 @@ The keys in the config file are defined as follows. All parameters are required 
 - `"date_list"`: [Only use `"date_list"` if also setting `'slq_parse_key'`, otherwise exclude `"date_list"` from config file] A list of arbitrary dates. Will be used to populate part of the resultant file name and may be used to determine query logic. It must be set as:
   - `["YYYYMMDD","YYYMMDD","YYYMMDD"]` value where `YYYY` is a 4-digit year value, `MM` is a 2-digit month value, and `DD` is a two digit day value. For example: `"20200220"` would represent a start date of February 20th, 2020. You may request one or multiple dates.
 - `"extension"`: [OPTIONAL] specify a file extension that you would like to append to the object. If no extension is set, no extension will be appended to the object. Needs to have a period included in the value specified. For example: `".csv"`
+- `"escape"`: [OPTIONAL] setting this to true will escape linefeeds `\n`, carrage returns `\r`, the escape character `\`, quotation mark characters `'` or `"` (if both ESCAPE and ADDQUOTES are specified in the UNLOAD command), or the delimiter character `|` pipe (default) or the character specified in `"delimiter"`, with a backslash `\`, defaults to `False`
 - `"delimiter"`: [OPTIONAL] specify a single ASCII character that is used to separate fields in the output file, such as a pipe character `|`, a comma `,`, or a tab `\t`. If the delimiter is not set, it will default to use the pipe character `|` as the delimiter.
+- `"addquotes"`: [OPTIONAL] setting this to true will surround all values in the file with double quotes `"`, defaults to `True`
 
 ### DML File
 

--- a/redshift_to_s3/config.d/example.json
+++ b/redshift_to_s3/config.d/example.json
@@ -8,5 +8,6 @@
   "header": false,
   "sql_parse_key": "pmrp_date_range",
   "start_date": "unsent",
-  "end_date": "max"
+  "end_date": "max",
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/pmrp_all.json
+++ b/redshift_to_s3/config.d/pmrp_all.json
@@ -8,5 +8,6 @@
   "header": false,
   "sql_parse_key": "pmrp_date_range",
   "start_date": "min",
-  "end_date": "max"
+  "end_date": "max",
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/pmrp_date_range.json
+++ b/redshift_to_s3/config.d/pmrp_date_range.json
@@ -8,5 +8,6 @@
   "header": false,
   "sql_parse_key": "pmrp_date_range",
   "start_date": "unsent",
-  "end_date": "max"
+  "end_date": "max",
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/pmrp_max_date.json
+++ b/redshift_to_s3/config.d/pmrp_max_date.json
@@ -7,7 +7,7 @@
   "dml": "pmrp_date_range.sql",
   "header": false,
   "sql_parse_key": "pmrp_date_range",
-  "start_date": "unset",
+  "start_date": "unsent",
   "end_date": "max",
   "addquotes": false
 }

--- a/redshift_to_s3/config.d/pmrp_max_date.json
+++ b/redshift_to_s3/config.d/pmrp_max_date.json
@@ -8,5 +8,6 @@
   "header": false,
   "sql_parse_key": "pmrp_date_range",
   "start_date": "unset",
-  "end_date": "max"
+  "end_date": "max",
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/pmrp_qdata_daily.json
+++ b/redshift_to_s3/config.d/pmrp_qdata_daily.json
@@ -5,5 +5,6 @@
   "directory": "pmrp_qdata/daily/Jun_2022_change",
   "object_prefix": "pmrp_qdata",
   "dml": "pmrp_qdata_daily.sql",
-  "header": true
+  "header": true,
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/pmrp_qdata_dates.json
+++ b/redshift_to_s3/config.d/pmrp_qdata_dates.json
@@ -7,5 +7,6 @@
   "dml": "pmrp_qdata_dates.sql",
   "header": true,
   "sql_parse_key": "pmrp_qdata_dates",
-  "date_list":["2021-01-01","2021-02-04","2021-05-08"]
+  "date_list":["2021-01-01","2021-02-04","2021-05-08"],
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/pmrp_qdata_range.json
+++ b/redshift_to_s3/config.d/pmrp_qdata_range.json
@@ -8,5 +8,6 @@
   "header": true,
   "sql_parse_key": "pmrp_date_range",
   "start_date": "20180508",
-  "end_date": "20220622"
+  "end_date": "20220622",
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/sbc-sdpr_historical.json
+++ b/redshift_to_s3/config.d/sbc-sdpr_historical.json
@@ -7,5 +7,6 @@
   "dml": "sbc-sdpr_historical.sql",
   "header": true,
   "extension": ".csv",
-  "delimiter": ","
+  "delimiter": ",",
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/sbc-sdpr_last_full_day_incremental.json
+++ b/redshift_to_s3/config.d/sbc-sdpr_last_full_day_incremental.json
@@ -7,5 +7,6 @@
   "dml": "sbc-sdpr_last_full_day_incremental.sql",
   "header": true,
   "extension": ".csv",
-  "delimiter": ","
+  "delimiter": ",",
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/sdpr_historical.json
+++ b/redshift_to_s3/config.d/sdpr_historical.json
@@ -5,5 +5,6 @@
   "directory": "theq_sdpr/historical",
   "object_prefix": "sdpr",
   "dml": "sdpr_historical.sql",
-  "header": true
+  "header": true,
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/sdpr_hourly.json
+++ b/redshift_to_s3/config.d/sdpr_hourly.json
@@ -7,5 +7,6 @@
   "dml": "sdpr_hourly.sql",
   "header": true,
   "extension": ".csv",
-  "delimiter": ","
+  "delimiter": ",",
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/sdpr_last_full_day.json
+++ b/redshift_to_s3/config.d/sdpr_last_full_day.json
@@ -5,5 +5,6 @@
   "directory": "theq_sdpr/daily",
   "object_prefix": "sdpr",
   "dml": "sdpr_last_full_day.sql",
-  "header": true
+  "header": true,
+  "addquotes": false
 }

--- a/redshift_to_s3/config.d/sdpr_last_full_day_incremental.json
+++ b/redshift_to_s3/config.d/sdpr_last_full_day_incremental.json
@@ -7,5 +7,6 @@
   "dml": "sdpr_last_full_day_incremental.sql",
   "header": true,
   "extension": ".csv",
-  "delimiter": ","
+  "delimiter": ",",
+  "addquotes": false
 }

--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -77,6 +77,8 @@ header = config['header']
 sql_parse_key = \
     False if 'sql_parse_key' not in config else config['sql_parse_key']
 
+escape = True if 'escape' not in config else config['escape']
+
 delimiter = False if 'delimiter' not in config else config['delimiter']
 
 addquotes = True if 'addquotes' not in config else config['addquotes']
@@ -373,6 +375,13 @@ if sql_parse_key:
     # pass the keyword_dict to the request query formatter
     request_query = request_query.format(**keyword_dict)
 
+# If there is no escape specified in the config file
+# leave it blank, else build the escape string for the UNLOAD query
+if escape:
+    escape_string = "ESCAPE"
+else:
+    escape_string = ""
+
 # If there is no delimiter specified in the config file
 # build the delimiter string for the UNLOAD query, else leave it blank
 if delimiter:
@@ -395,6 +404,7 @@ UNLOAD ('{request_query}')
 TO 's3://{bucket}/{batch_prefix}/{object_key}_part'
 credentials 'aws_access_key_id={aws_access_key_id};\
 aws_secret_access_key={aws_secret_access_key}'
+{escape_string}
 {delimiter_string}
 {addquotes_string}
 PARALLEL OFF
@@ -406,6 +416,7 @@ PARALLEL OFF
     object_key=object_key,
     aws_access_key_id='{aws_access_key_id}',
     aws_secret_access_key='{aws_secret_access_key}',
+    escape_string=escape_string,
     delimiter_string=delimiter_string,
     addquotes_string=addquotes_string,
     header='HEADER' if header else '')

--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -77,10 +77,14 @@ header = config['header']
 sql_parse_key = \
     False if 'sql_parse_key' not in config else config['sql_parse_key']
 
-escape = True if 'escape' not in config else config['escape']
+# if escape option is missing from the config, set as disabled
+escape = False if 'escape' not in config else config['escape']
 
+# if delimiter option is missing from the config, set as disabled
 delimiter = False if 'delimiter' not in config else config['delimiter']
 
+# if addquotes option is missing from the config, set as enabled
+# even with this option enabled Excel will break when in a value a " appears before a delimiter character
 addquotes = True if 'addquotes' not in config else config['addquotes']
 
 if 'date_list' in config:
@@ -375,22 +379,22 @@ if sql_parse_key:
     # pass the keyword_dict to the request query formatter
     request_query = request_query.format(**keyword_dict)
 
-# If there is no escape specified in the config file
-# leave it blank, else build the escape string for the UNLOAD query
+# If escape was enabled, create string needed to be added to UNLOAD command 
+# else adds a blank string
 if escape:
     escape_string = "ESCAPE"
 else:
     escape_string = ""
 
-# If there is no delimiter specified in the config file
-# build the delimiter string for the UNLOAD query, else leave it blank
+# If delimiter was enabled, create string needed to be added to UNLOAD command 
+# else adds a blank string
 if delimiter:
     delimiter_string = "delimiter '{delimiter}'".format(delimiter=delimiter)
 else:
     delimiter_string = ""
 
-# If there is no addquotes specified in the config file
-# leave it blank, else build the addquotes string for the UNLOAD query
+# If addquotes was enabled, create string needed to be added to UNLOAD command 
+# else adds a blank string
 if addquotes:
     addquotes_string = "ADDQUOTES"
 else:

--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -79,6 +79,8 @@ sql_parse_key = \
 
 delimiter = False if 'delimiter' not in config else config['delimiter']
 
+addquotes = True if 'addquotes' not in config else config['addquotes']
+
 if 'date_list' in config:
     dates = config['date_list']
 
@@ -378,6 +380,13 @@ if delimiter:
 else:
     delimiter_string = ""
 
+# If there is no addquotes specified in the config file
+# leave it blank, else build the addquotes string for the UNLOAD query
+if addquotes:
+    addquotes_string = "ADDQUOTES"
+else:
+    addquotes_string = ""
+
 # The UNLOAD query to support S3 loading direct from a Redshift query
 # ref: https://docs.aws.amazon.com/redshift/latest/dg/r_UNLOAD.html
 # This UNLOAD inserts into the S3 BATCH path
@@ -387,6 +396,7 @@ TO 's3://{bucket}/{batch_prefix}/{object_key}_part'
 credentials 'aws_access_key_id={aws_access_key_id};\
 aws_secret_access_key={aws_secret_access_key}'
 {delimiter_string}
+{addquotes_string}
 PARALLEL OFF
 {header}
 '''.format(
@@ -397,6 +407,7 @@ PARALLEL OFF
     aws_access_key_id='{aws_access_key_id}',
     aws_secret_access_key='{aws_secret_access_key}',
     delimiter_string=delimiter_string,
+    addquotes_string=addquotes_string,
     header='HEADER' if header else '')
 
 query = log_query.format(


### PR DESCRIPTION
This PR does the following:
1. Adds redshift_to_s3 config option to set ADDQUOTES in the UNLOAD, and default to enabled
2. Adds redshift_to_s3 config option to set ESCAPE in the UNLOAD, and default to disabled
3. Update existing configs to use the options that were set before these changes
 
Testing notes:

There will three sections to the testing
1. Reviewing the changes to the file
2. Testing the functionality of the ADDQUOTES and ESCAPE options
3. Checking to see that the current data is produced with the same settings as before these changes

These tests will use modified configs that do not appear in the PR. You can view these modified test configs in the ticket

Testing instructions:
1. Review [README.md](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5611-add-quotes-around-text-option-to-redshift-to-s3/redshift_to_s3/README.md) for understanding and clarity
2. Review the changes in [redshift_to_s3.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5611-add-quotes-around-text-option-to-redshift-to-s3/redshift_to_s3/redshift_to_s3.py): 
3. Review the configs in [config.d](https://github.com/bcgov/GDX-Analytics-microservice/tree/GDXDSD-5611-add-quotes-around-text-option-to-redshift-to-s3/redshift_to_s3/config.d) to make sure "addquotes" is set to False and that "escape" is missing (thereby defaulting to false): 
4. Compare the configs in [config.d](https://github.com/bcgov/GDX-Analytics-microservice/tree/GDXDSD-5611-add-quotes-around-text-option-to-redshift-to-s3/redshift_to_s3/config.d) with the test configs in the ticket, making sure that the only change being that 'doug_test/GDXDSD-5611/' is put at the start of the "directory" option
5. Log into the ec2 instance through the following commands
```
awsmfa prod <AWS OTP>
microservice_ssm
cd /home/microservice/branch/GDXDSD-5611-add-quotes-around-text-option-to-redshift-to-s3/redshift_to_s3
```
6. Run the following commands and compare its output to what's expected:
```
pipenv run python redshift_to_s3.py -c config.d/GDXDSD-5611-default.json && pipenv run python redshift_to_s3.py -c config.d/GDXDSD-5611-yes-addquotes-no-escape.json && pipenv run python redshift_to_s3.py -c config.d/GDXDSD-5611-no-addquotes-yes-escape.json && pipenv run python redshift_to_s3.py -c config.d/GDXDSD-5611-yes-addquotes-yes-escape.json && pipenv run python redshift_to_s3.py -c config.d/GDXDSD-5611-no-addquotes-no-escape.json
```
```
TBD
```
7. Check to see if the files appear in the s3 processed good bucket: 
- default settings: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/default/&showversions=false
- ADDQUOTES disabled, ESCAPE disabled: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/no-addquotes-no-escape/&showversions=false
- ADDQUOTES disabled, ESCAPE enabled: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/no-addquotes-yes-escape/&showversions=false
- ADDQUOTES enabled, ESCAPE disabled: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/yes-addquotes-no-escape/&showversions=false
- ADDQUOTES enabled, ESCAPE enabled: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/yes-addquotes-yes-escape/&showversions=false
8. Check to see if the files appear in the s3 client bucket and download your generated file: 
- default settings: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/default/&showversions=false
- ADDQUOTES disabled, ESCAPE disabled: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-9-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/no-addquotes-no-escape/&showversions=false
- ADDQUOTES disabled, ESCAPE enabled: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/no-addquotes-yes-escape/&showversions=false
- ADDQUOTES enabled, ESCAPE disabled: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/yes-addquotes-no-escape/&showversions=false
- ADDQUOTES enabled, ESCAPE enabled: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/yes-addquotes-yes-escape/&showversions=false
9. Run the following commands and compare its output to what's expected:
```
pipenv run python redshift_to_s3.py -c config.d/sdpr_last_full_day-test.json
pipenv run python redshift_to_s3.py -c config.d/sdpr_last_full_day_incremental-test.json
pipenv run python redshift_to_s3.py -c config.d/sdpr_hourly-test.json
pipenv run python redshift_to_s3.py -c config.d/sbc-sdpr_last_full_day_incremental-test.json
pipenv run python redshift_to_s3.py -c config.d/pmrp_qdata_dates-test.json
pipenv run python redshift_to_s3.py -c config.d/pmrp_qdata_daily-test.json
pipenv run python redshift_to_s3.py -c config.d/pmrp_all-test.json
pipenv run python redshift_to_s3.py -c config.d/pmrp_qdata_range-test.json
pipenv run python redshift_to_s3.py -c config.d/sbc-sdpr_historical-test.json
pipenv run python redshift_to_s3.py -c config.d/sdpr_historical-test.json
pipenv run python redshift_to_s3.py -c config.d/pmrp_date_range-test.json
pipenv run python redshift_to_s3.py -c config.d/pmrp_max_date-test.json
```
10. Check to see if the files appear in the s3 processed good bucket: 
- sdpr_last_full_day-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/theq_sdpr/daily/&showversions=false
- sdpr_last_full_day_incremental-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/theq_sdpr/daily-incremental/v01-Mar_2023_incremental/&showversions=false
- sdpr_hourly-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/theq_sdprabi/sdpr_hourly/v01-Mar_2023_incremental/&showversions=false
- sbc-sdpr_last_full_day_incremental-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/theq_sdpr/sbc-sdpr_daily-incremental/v03-May_2023_folder_change/&showversions=false
- pmrp_qdata_dates-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/pmrp_qdata/dates/Jun_2022_change/&showversions=false
- pmrp_qdata_daily-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/pmrp_qdata/daily/Jun_2022_change/&showversions=false
- pmrp_all-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/pmrp_gdx/pmrp_all/&showversions=false
- pmrp_qdata_range-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/pmrp_qdata/range/Jun_2022_change/&showversions=false
- sbc-sdpr_historical-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/theq_sdpr/sbc-sdpr_historical/v03-May_2023_folder_change/&showversions=false
- sdpr_historical-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/theq_sdpr/historical/&showversions=false
- pmrp_date_range-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/pmrp_gdx/pmrp_date_range/&showversions=false
- pmrp_max_date-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=processed/good/client/doug_test/GDXDSD-5611/pmrp_gdx/pmrp_max_date/&showversions=false
11. Check to see if the files appear in the s3 client bucket and download both files to compare and see if the file formats are the same: 
- sdpr_last_full_day-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/theq_sdpr/daily/&showversions=false
- sdpr_last_full_day_incremental-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/theq_sdpr/daily-incremental/v01-Mar_2023_incremental/&showversions=false
- sdpr_hourly-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/theq_sdprabi/sdpr_hourly/v01-Mar_2023_incremental/&showversions=false
- sbc-sdpr_last_full_day_incremental-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/theq_sdpr/sbc-sdpr_daily-incremental/v03-May_2023_folder_change/&showversions=false
- pmrp_qdata_dates-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/pmrp_qdata/dates/Jun_2022_change/&showversions=false
- pmrp_qdata_daily-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/pmrp_qdata/daily/Jun_2022_change/&showversions=false
- pmrp_all-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/pmrp_gdx/pmrp_all/&showversions=false
- pmrp_qdata_range-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/pmrp_qdata/range/Jun_2022_change/&showversions=false
- sbc-sdpr_historical-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/theq_sdpr/sbc-sdpr_historical/v03-May_2023_folder_change/&showversions=false
- sdpr_historical-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/theq_sdpr/historical/&showversions=false
- pmrp_date_range-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/pmrp_gdx/pmrp_date_range/&showversions=false
- pmrp_max_date-test: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&prefix=client/doug_test/GDXDSD-5611/pmrp_gdx/pmrp_max_date/&showversions=false