### PR TITLE
Gdxdsd 5888 remove log print of passwords for s3 to sfts

### DIFF
--- a/lib/logs.py
+++ b/lib/logs.py
@@ -42,7 +42,7 @@ class CustomFormatter(logging.Formatter):
     """ Formatter that applies custom filters to the log outputs 
     """
     @staticmethod
-    def _SFTSXferPasswordFilter(s):
+    def _PasswordFilter(s):
         """ Uses regex to search the log formatter for a password. The password 
         is identifed as a 0 or more string of any characters that is found 
         between '-password:' and '-quiterror'
@@ -53,7 +53,7 @@ class CustomFormatter(logging.Formatter):
         """ Applies the custom filters to the formatter
         """
         original = logging.Formatter.format(self, record)
-        filtered = self._SFTSXferPasswordFilter(original)
+        filtered = self._PasswordFilter(original)
         return filtered 
 
 def setup(dir='logs', minLevel=logging.INFO):

--- a/lib/logs.py
+++ b/lib/logs.py
@@ -43,9 +43,19 @@ class CustomFormatter(logging.Formatter):
     """
     @staticmethod
     def _PasswordFilter(s):
-        """ Uses regex to search the log formatter for a password. The password 
-        is identifed as a 0 or more string of any characters that is found 
-        between '-password:' and '-quiterror'
+        """ Uses regex to identify and redact passwords in the log outputs. 
+
+        This filter identifies and redacts a password that is written to the logs 
+        in the S3 to SFTS microservice upon error. Because the structure of this 
+        error is known, a password is identified as the text between two string 
+        literals, '-password:' and '-quiterror'. If no password is identified by 
+        the regex, no redaction is made. There is a small chance that the regex 
+        expression identifies text that is not actually part of the password if 
+        it appears between the -password:' and '-quiterror' string literals. In 
+        this case, all of that text will be redacted and lost in addition to the 
+        password. This is a known bug, but the chances of it occurring has been 
+        identified as low enough that the code in it's current state is approved 
+        for use in production.  
         """
         return re.sub(r"-password:.*?-quiterror", r"-password:********', '-quiterror", s)
 


### PR DESCRIPTION
This PR does the following:
Modifies [logs.py](https://github.com/bcgov/GDX-Analytics-microservice/compare/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts?expand=1#diff-862ea78dbb073f087154dfb47e7c6cd623eec6432b0f695f77fb7e3aaa96bdd5) to add a custom formatter that will redact passwords that can appear in the logs of [s3_to_sfts.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_sfts/s3_to_sfts.py)
Testing this PR will involve both the changes for [s3_to_sfts.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_sfts/s3_to_sfts.py) as well as the affect on any microservice that uses [logs.py](https://github.com/bcgov/GDX-Analytics-microservice/compare/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts?expand=1#diff-862ea78dbb073f087154dfb47e7c6cd623eec6432b0f695f77fb7e3aaa96bdd5)

Please note that there are modified files on the ec2 instance needed for these test. Files also need to be modified during the testing of the PR. The modified files will be added to the ticket once the PR review has been completed.

Testing Notes:

1. Review [logs.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/lib/logs.py), making sure that the comments about the code are clear and easy to understand
2. When reviewing the log files, we are looking to see if there are any unintended edits made by our custom formatter. While this could happen at any place in the log file, it is most likely to happen if "password" appears. 
3. Running theses tests may have a large impact on Redshift disk space. Please make sure you are not running these tests when the disk space is already high and monitor the impact while the tests are running. 

Testing prep:

1. Log into the ec2 instance through the following commands
```
$ awsmfa prod <AWS OTP>
$ microservice_ssm
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts
```

Testing the redaction of passwords from s3_to_sfts.py

1. Navigate to the s3_to_sfts microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_sfts
```
2. Run the following command and compare to the expected results
```
$ pipenv run python s3_to_sfts.py -c config.d/GDXDSD-5888.json 
Report: s3_to_sfts.py

Config: config.d/GDXDSD-5888.json
*** ATTN: The microservice ran unsuccessfully. ***


Microservice started at: 2023-11-06 16:07:23-0800 (PST), ended at: 2023-11-06 16:07:26-0800 (PST), elapsing: 0:00:02.436211.

Items to process: 1
Objects successfully processed to sfts: 0
Objects that failed to process to sfts: 1
Objects successfully processed to s3: 1
Objects that failed to process to s3: 0

List of objects that failed to process to sfts:

1: client/doug_test/GDXDSD-5888/data_client/GDXDSD-5888_test1.txt

List of objects copied to S3 bad archives:

1: client/doug_test/GDXDSD-5888/data_client/GDXDSD-5888_test1.txt
```
3. Check the logs for this run of the microservice and confirm that the password was redacted
```
$ vim logs/s3_to_sfts.log 
```

==============================

Testing the effects on [cmslitemetadata_to_redshift.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/cmslitemetadata_to_redshift/cmslitemetadata_to_redshift.py):

1. Navigate to the cmslitemetadata_to_redshift microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/cmslitemetadata_to_redshift
```
2. Run the following command to create the test table
```
$ microservice_rs < ddl/test.cmslite_test.sql
```
3. Log the results of the command into the ticket
4. Run the following command and compare to the expected results
```
$ pipenv run python cmslitemetadata_to_redshift.py cmslite_test.json
Report cmslitemetadata_to_redshift.py:


Config: cmslite_test.json


Microservice started at: 2023-10-23 14:24:29-0700 (PDT), ended at: 2023-10-23 14:39:55-0700 (PDT), elapsing: 0:15:25.776523.


Objects to process: 1
Objects successfully processed: 1
Objects that failed to process: 0
Objects output to 'processed/good': 1
Objects output to 'processed/bad': 0
Objects loaded to Redshift: 2


List of objects successfully fully ingested from S3, processed, loaded to S3 ('good'), and copied to Redshift:
1: client/test_cmslite/cmslite.csv.2022-03-19


List of tables that were successfully loaded into Redshift:
test.metadata
test.themes 
```
5. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
vim logs/cmslitemetadata_to_redshift.log
```

==============================

Testing the effects on [google_mybusiness.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/google-api/google_mybusiness.py):

1. Navigate to the google_mybusiness microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/google-api
```
2. Run the following command to create the test table
```
$ microservice_rs < GDXDSD-5888-test.gdxdsd_5888_google_mybusiness.sql
```
3. Modify GDXDSD-5888_config_mybusiness.json, changing the "start_date" to a day that is 4 days before you are running this test
```
$ vim GDXDSD-5888_config_mybusiness.json 
```
4. Log the results of the command in the ticket
5. Run the following command and compare to the expected results
```
$ pipenv run python google_mybusiness.py -o credentials_mybusiness.json -a credentials_mybusiness.dat -c GDXDSD-5888_config_mybusiness.json
Report: google_mybusiness.py


Config: GDXDSD-5888_config_mybusiness.json


Microservice started at: 2023-11-03 10:13:14-0700 (PDT), ended at: 2023-11-03 10:17:54-0700 (PDT), elapsing: 0:04:40.175997.


Locations to process: 64
Successful API calls: 64
Failed API calls: 0
Successful loads to RedShift: 64
Failed loads to RedShift: 0
Files loads to S3 /good: 64
Files loads to S3 /bad: 0
Sites failed due to hitting an error: 0


Objects loaded RedShift and to S3 /good:
1: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Kelowna_2023-10-30_2023-10-31.csv
2: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Chetwynd_2023-10-30_2023-10-31.csv
3: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Williams-Lake_2023-10-30_2023-10-31.csv
4: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Valemount_2023-10-30_2023-10-31.csv
5: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Oliver_2023-10-30_2023-10-31.csv
6: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Fort-St.-John_2023-10-30_2023-10-31.csv
7: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Port-Alberni_2023-10-30_2023-10-31.csv
8: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Prince-George-(ICBC-Driver-Licensing---no-Road-Tests)_2023-10-30_2023-10-31.csv
9: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Kamloops-(No-Driver-Services)_2023-10-30_2023-10-31.csv
10: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Atlin_2023-10-30_2023-10-31.csv
11: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Kaslo_2023-10-30_2023-10-31.csv
12: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Ashcroft_2023-10-30_2023-10-31.csv
13: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Vancouver-(Limited-Services)_2023-10-30_2023-10-31.csv
14: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Fort-Nelson_2023-10-30_2023-10-31.csv
15: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Cranbrook_2023-10-30_2023-10-31.csv
16: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Vernon_2023-10-30_2023-10-31.csv
17: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Creston_2023-10-30_2023-10-31.csv
18: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Powell-River_2023-10-30_2023-10-31.csv
19: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Salmon-Arm_2023-10-30_2023-10-31.csv
20: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Squamish_2023-10-30_2023-10-31.csv
21: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Bella-Coola_2023-10-30_2023-10-31.csv
22: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Princeton_2023-10-30_2023-10-31.csv
23: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Golden_2023-10-30_2023-10-31.csv
24: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Nakusp_2023-10-30_2023-10-31.csv
25: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Stewart_2023-10-30_2023-10-31.csv
26: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Victoria_2023-10-30_2023-10-31.csv
27: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Hazelton_2023-10-30_2023-10-31.csv
28: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Quesnel_2023-10-30_2023-10-31.csv
29: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Masset_2023-10-30_2023-10-31.csv
30: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Burns-Lake_2023-10-30_2023-10-31.csv
31: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Dease-Lake_2023-10-30_2023-10-31.csv
32: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Nelson_2023-10-30_2023-10-31.csv
33: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Ucluelet_2023-10-30_2023-10-31.csv
34: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Terrace_2023-10-30_2023-10-31.csv
35: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Sechelt_2023-10-30_2023-10-31.csv
36: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Surrey-(Limited-Services)_2023-10-30_2023-10-31.csv
37: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Fort-St.-James_2023-10-30_2023-10-31.csv
38: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Mackenzie_2023-10-30_2023-10-31.csv
39: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Penticton_2023-10-30_2023-10-31.csv
40: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Maple-Ridge_2023-10-30_2023-10-31.csv
41: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Lillooet_2023-10-30_2023-10-31.csv
42: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Trail_2023-10-30_2023-10-31.csv
43: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Chilliwack_2023-10-30_2023-10-31.csv
44: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Invermere_2023-10-30_2023-10-31.csv
45: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Courtenay_2023-10-30_2023-10-31.csv
46: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Fernie_2023-10-30_2023-10-31.csv
47: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Clinton_2023-10-30_2023-10-31.csv
48: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Duncan_2023-10-30_2023-10-31.csv
49: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Smithers_2023-10-30_2023-10-31.csv
50: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-100-Mile-House_2023-10-30_2023-10-31.csv
51: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Grand-Forks_2023-10-30_2023-10-31.csv
52: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Daajing-Giids_2023-10-30_2023-10-31.csv
53: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Prince-Rupert_2023-10-30_2023-10-31.csv
54: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Port-Hardy_2023-10-30_2023-10-31.csv
55: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Dawson-Creek_2023-10-30_2023-10-31.csv
56: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Burnaby-(Limited-Services)_2023-10-30_2023-10-31.csv
57: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Ganges_2023-10-30_2023-10-31.csv
58: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Vanderhoof_2023-10-30_2023-10-31.csv
59: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Merritt_2023-10-30_2023-10-31.csv
60: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Revelstoke_2023-10-30_2023-10-31.csv
61: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Sparwood_2023-10-30_2023-10-31.csv
62: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Houston_2023-10-30_2023-10-31.csv
63: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Kitimat_2023-10-30_2023-10-31.csv
64: processed/good/client/doug_test/GDXDSD-5888/google_mybusiness/servicebc/gmb_Service-BC-Centre-Campbell-River_2023-10-30_2023-10-31.csv 
```
6. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
$ vim logs/google_mybusiness.log
```

==============================

Testing the effects on [google_mybusiness_servicebc_derived.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/google-api/google_mybusiness_servicebc_derived.py):

1. Navigate to the google_mybusiness_servicebc_derived microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/google-api
```
2. Run the following command and compare to the expected results
```
$ pipenv run python google_mybusiness_servicebc_derived.py -c GDXDSD-5888-config_servicebc.json 
Success: executed the transaction to prepare the google_mybusiness_servicebc_derived DT
```
3. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
$ vim logs/google_mybusiness_servicebc_derived.log
```

==============================

Testing the effects on [google_search.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/google-api/google_search.py):

1. Navigate to the google_search microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/google-api
```
2. Run the following command and query to create the test table
```
$ microservice_rs
snowplow=> CREATE TABLE test.gdxdsd_5888_googlesearch (LIKE google.googlesearch);
CREATE TABLE
snowplow=> GRANT SELECT ON TABLE test.gdxdsd_5888_googlesearch TO LOOKER;
GRANT 
snowplow=> \q
```
3. Modify GDXDSD-5888_config_search.json, changing both "start_date_default" values to a day that is 4 days before the time of testing
```
$ vim GDXDSD-5888_config_search.json 
```
4. Log the results of your queries in the ticket
5. Run the following command and compare to the expected results
```
$ pipenv run python google_search.py -o credentials_search.json -a credentials_search.dat -c GDXDSD-5888_config_search.json 
Report: google_search.py


Config: GDXDSD-5888_config_search.json


Google Search derived table build not attempted
Microservice started at: 2023-11-03 11:41:51-0700 (PDT), ended at: 2023-11-03 11:41:51-0700 (PDT), elapsing: 0:00:00.000044.


Sites to process: 2
Successful API calls: 2
Failed API calls: 0
Failed loads to RedShift: 0




Objects loaded to S3 and copied to RedShift:
1: s3://sp-ca-bc-gov-131565110619-12-microservices/client/doug_test/GDXDSD-5888/google_gdx/googlesearch-search.onlinelearningbc.com-2023-10-30-2023-10-31.csv 
```
6. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
$ vim logs/google_search.log
```

==============================

Testing the effects on [looker_dashboard_usage.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/looker_dashboard_usage/looker_dashboard_usage.py):

1. Navigate to the looker_dashboard_usage microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/looker_dashboard_usage
```
4. Run the following command and compare to the expected results
```
$ pipenv run python looker_dashboard_usage.py GDXDSD-5888-looker_dashboard_usage.json 
Report: looker_dashboard_usage.py


Config: GDXDSD-5888-looker_dashboard_usage.json


This microservice ran: successful


Microservice started at: 2023-10-23 15:08:54-0700 (PDT), ended at: 2023-10-23 15:08:55-0700 (PDT), elapsing: 0:00:01.112121.


Objects to process: 4
Objects that failed to process: 0
Objects output to 'processed/good': 4
Objects output to 'processed/bad': 0


List of objects successfully fully ingested from S3, processed, loaded to S3 ('good'), and copied to Redshift:
1. client/doug_test/GDXDSD-5888/looker_dashboards/dashboard.2023-10-22
2. client/doug_test/GDXDSD-5888/looker_dashboards/history.2023-10-22
3. client/doug_test/GDXDSD-5888/looker_dashboards/user.2023-10-22
4. client/doug_test/GDXDSD-5888/looker_dashboards/looker_user_facts.2023-10-22 
```
5. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
$ vim logs/looker_dashboard_usage.log 
```

==============================

Testing the effects on [redshift_to_s3.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/redshift_to_s3/redshift_to_s3.py) (Note: this must be ran before [s3_to_sfts.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_sfts/s3_to_sfts.py)):

1. Navigate to the redshift_to_s3 microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/redshift_to_s3
```
4. Run the following command and compare to the expected results
```
$ pipenv run python redshift_to_s3.py -c config.d/GDXDSD-5888-redshift_to_s3.json 


***The microservice ran successfully***


Report: redshift_to_s3.py


Config: config.d/GDXDSD-5888-redshift_to_s3.json


DML: pmrp_qdata_daily.sql


Microservice started at: 2023-10-20 16:18:16-0700 (PDT), ended at: 2023-10-20 16:18:17-0700 (PDT), elapsing: 0:00:01.537924.




Objects loaded to S3 /batch: 1/1
Objects successfully loaded to S3 /batch: 1


List of objects successfully loaded to S3 /batch
1. processed/batch/client/doug_test/GDXDSD-5888/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20231020T231816




Objects to store: 1
Objects stored to s3 /client: 1


List of objects stored to S3 /client:
1: client/doug_test/GDXDSD-5888/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20231020T231816_part000




Objects to process: 1
Objects processed to s3 /good: 1


List of objects processed to S3 /good:
1: processed/good/client/doug_test/GDXDSD-5888/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20231020T231816_part000
```
5. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
$ vim logs/redshift_to_s3.log
```

==============================

Testing the effects on [asset_data_to_redshift.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_redshift/asset_data_to_redshift.py) (Note: this must be ran before [build_derived_assets.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_redshift/build_derived_assets.py)):

1. Navigate to the asset_data_to_redshift microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_redshift
```
2. Run the following command to create the test table:
```
$ microservice_rs < ddl/GDXDSD-5888-test.gdxdsd_5888_asset_downloads.sql 
SET
CREATE TABLE
GRANT 
```
3. Log the results of the command into the ticket
4. Run the following command and compare to the expected results
```
$ pipenv run python asset_data_to_redshift.py config.d/GDXDSD-5888_intranet_assets.json 
Report: asset_data_to_redshift.py


Config: config.d/GDXDSD-5888_intranet_assets.json


Microservice started at: 2023-10-31 09:27:00-0700 (PDT), ended at: 2023-10-31 09:27:41-0700 (PDT), elapsing: 0:00:40.788221.


Objects to process: 1
Objects successfully processed: 1
Objects that failed to process: 0
Objects output to 'processed/good': 1
Objects output to 'processed/bad': 0
Objects loaded to Redshift: 1
Empty Objects: 0


List of objects successfully fully ingested from S3, processed, loaded to S3 ('good'), and copied to Redshift:
1: client/doug_test/GDXDSD-5888/cmslite_gdx/intranet_apache.2023-10-30 
```
5. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
$ vim logs/asset_data_to_redshift.log 
```

==============================

Testing the effects on [build_derived_assets.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_redshift/build_derived_assets.py) (Note: this must be ran after [asset_data_to_redshift.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_redshift/asset_data_to_redshift.py)):

1. Navigate to the build_derived_assets microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_redshift
```
2. Run the following command to create the test table
```
$ microservice_rs < GDXDSD-5888-test.gdxdsd_5888_asset_downloads_derived.sql 
SET
CREATE TABLE
GRANT 
```
3. Log the results of the command into the ticket
4. Run the following command and compare to the expected results
```
$ pipenv run python build_derived_assets.py config.d/GDXDSD-5888_intranet_assets.json 


Report build_derived_assets.py:


Config: config.d/GDXDSD-5888_intranet_assets.json


Microservice started at: 2023-10-31 13:23:35-0700 (PDT), ended at: 2023-10-31 13:24:01-0700 (PDT), elapsing: 0:00:25.065551.


Objects to process: 1
Objects that failed to process: 0
Objects loaded to Redshift: 1


List of tables successfully parsed, and copied to the derived table in Redshift:
test.gdxdsd_5888_asset_downloads


-----------------

 

```
5. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
$ vim logs/build_derived_assets.log
```

==============================

Testing the effects on [cmslite_user_data_to_redshift.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_redshift/cmslite_user_data_to_redshift.py):

1. Navigate to the cmslite_user_data_to_redshift microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_redshift
```
2. Run the following commands to create the 4 test tables:
```
$ microservice_rs < ddl/GDXDSD-5888-test.gdxdsd_5888_groups.sql 
SET
CREATE TABLE
GRANT
$ microservice_rs < ddl/GDXDSD-5888-test.gdxdsd_5888_user_access.sql 
SET
CREATE TABLE
GRANT
$ microservice_rs < ddl/GDXDSD-5888-test.gdxdsd_5888_user_activity.sql 
SET
CREATE TABLE
GRANT
$ microservice_rs < ddl/GDXDSD-5888-test.gdxdsd_5888_user_groups.sql 
SET
CREATE TABLE
GRANT 
```
3.  Log the results of the command into the ticket
4. Run the following command and compare to the expected results
```
$ pipenv run python cmslite_user_data_to_redshift.py config.d/GDXDSD-5888_cmslite_user_group_metadata.json
Report cmslite_user_data_to_redshift.py:


Config: config.d/GDXDSD-5888_cmslite_user_group_metadata.json


Microservice started at: 2023-10-30 15:11:15-0700 (PDT), ended at: 2023-10-30 15:12:15-0700 (PDT), elapsing: 0:01:00.754778.


Objects to process: 1
Objects successfully processed: 1
Objects that failed to process: 0
Objects output to 'processed/good': 1
Objects output to 'processed/bad': 0
Tables loaded to Redshift: 4/4


List of objects successfully fully ingested from S3, processed, loaded to S3 ('good'), and copied to Redshift:
client/doug_test/GDXDSD-5888/cmslite_gdx/cms-analytics-csv.2023-10-24.tgz


List of tables that were successfully loaded into Redshift:
test.gdxdsd_5888_cms_group
test.gdxdsd_5888_user_activity
test.gdxdsd_5888_user_group
test.gdxdsd_5888_user_status 
```
5. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
$ vim logs/cmslite_user_data_to_redshift.log
```

==============================

Testing the effects on [s3_to_sfts.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_sfts/s3_to_sfts.py) (Note: this must be ran after [redshift_to_s3.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/redshift_to_s3/redshift_to_s3.py)):

1. Navigate to the s3_to_sfts microservice:
```
$ cd /home/microservice/branch/GDXDSD-5888-remove-log-print-of-passwords-for-s3-to-sfts/s3_to_sfts
```
2. Run the following command and compare to the expected results
```
$ pipenv run python s3_to_sfts.py -c config.d/GDXDSD-5888-s3_to_sfts.json 
Report: s3_to_sfts.py


Config: config.d/GDXDSD-5888-s3_to_sfts.json
***The microservice ran successfully***




Microservice started at: 2023-10-20 16:26:42-0700 (PDT), ended at: 2023-10-20 16:26:47-0700 (PDT), elapsing: 0:00:05.035987.


Items to process: 1
Objects successfully processed to sfts: 1
Objects that failed to process to sfts: 0
Objects successfully processed to s3: 1
Objects that failed to process to s3: 0


List of objects processed to sfts:


1: client/doug_test/GDXDSD-5888/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20231020T231816_part000


List of objects copied to S3 good archives:


1: client/doug_test/GDXDSD-5888/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20231020T231816_part000
```
3. Check the logs for this run of the microservice and confirm that the logs weren't accidentally modified by the custom formatter
```
$ vim logs/s3_to_sfts.log 
```