### PR TITLE
Gdxdsd 6356 dependabot urllib3 upgrade 1

### DIFF
--- a/cmslitemetadata_to_redshift/Pipfile.lock
+++ b/cmslitemetadata_to_redshift/Pipfile.lock
@@ -202,10 +202,10 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
-                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0",
+                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"
             ],
-            "version": "==1.26.7"
+            "version": "==1.26.18"
         }
     },
     "develop": {}

--- a/redshift_to_s3/Pipfile.lock
+++ b/redshift_to_s3/Pipfile.lock
@@ -129,11 +129,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0",
+                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.14"
+            "version": "==1.26.18"
         }
     },
     "develop": {

--- a/s3_to_redshift/Pipfile.lock
+++ b/s3_to_redshift/Pipfile.lock
@@ -221,11 +221,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
-                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0",
+                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.7"
+            "version": "==1.26.18"
         }
     },
     "develop": {}

--- a/s3_to_sfts/Pipfile.lock
+++ b/s3_to_sfts/Pipfile.lock
@@ -129,11 +129,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
-                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
+                "sha256:f8ecc1bba5667413457c529ab955bf8c67b45db799d159066261719e328580a0",
+                "sha256:34b97092d7e0a3a8cf7cd10e386f401b3737364026c45e622aa02903dffe0f07"
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.14"
+            "version": "==1.26.18"
         }
     },
     "develop": {


### PR DESCRIPTION
### This PR does the following:

Updates urllib3 to v1.26.18 in the following microservices:

- [cmslitemetadata_to_redshift](https://github.com/bcgov/GDX-Analytics-microservice/tree/GDXDSD-6356_dependabot_urllib3_upgrade_1/cmslitemetadata_to_redshift)
- [s3_to_redshift](https://github.com/bcgov/GDX-Analytics-microservice/tree/GDXDSD-6356_dependabot_urllib3_upgrade_1/s3_to_redshift)
- [redshift_to_s3](https://github.com/bcgov/GDX-Analytics-microservice/tree/GDXDSD-6356_dependabot_urllib3_upgrade_1/redshift_to_s3)
- [s3_to_sfts](https://github.com/bcgov/GDX-Analytics-microservice/tree/GDXDSD-6356_dependabot_urllib3_upgrade_1/s3_to_sfts)

Please note that there are modified files on the ec2 instance needed for these test. The modified files will be added to the ticket once the PR review has been completed.

### Testing notes:

- Running theses tests may have a large impact on Redshift disk space. Please make sure you are not running these tests when the disk space is already high and monitor the impact while the tests are running.

### Testing prep:

1. Log into the ec2 instance through the following commands
```
$ awsmfa prod <AWS OTP>
$ microservice_ssm
$ cd /home/microservice/branch/GDXDSD-6356_dependabot_urllib3_upgrade_1
```

### Testing the cmslitemetadata_to_redshift microservice:

1. Change directory to the cmslitemetadata_to_redshift microservice:
```
$ cd /home/microservice/branch/GDXDSD-6356_dependabot_urllib3_upgrade_1/cmslitemetadata_to_redshift
```
2. Run the following command to test the cmslitemetadata_to_redshift.py microservice:
```
$ pipenv run python cmslitemetadata_to_redshift.py cmslite_test.json
```
3. Compare the cmslitemetadata_to_redshift.py output to the expected results:
```
Report cmslitemetadata_to_redshift.py:


Config: cmslite_test.json


Microservice started at: 2024-02-23 13:01:04-0800 (PST), ended at: 2024-02-23 13:15:08-0800 (PST), elapsing: 0:14:04.090446.


Objects to process: 1
Objects successfully processed: 1
Objects that failed to process: 0
Objects output to 'processed/good': 1
Objects output to 'processed/bad': 0
Objects loaded to Redshift: 2


List of objects successfully fully ingested from S3, processed, loaded to S3 ('good'), and copied to Redshift:
1: client/test_cmslite/cmslite.csv.2022-03-19


List of tables that were successfully loaded into Redshift:
test.metadata
test.themes 
```

### Testing the s3_to_redshift microservices:

1. Change directory to the s3_to_redshift microservices:
```
$ cd /home/microservice/branch/GDXDSD-6356_dependabot_urllib3_upgrade_1/s3_to_redshift
```
2. Run the following command to test the asset_data_to_redshift.py microservice: 
```
$ pipenv run python asset_data_to_redshift.py config.d/GDXDSD-6356_intranet_assets.json 
```
3. Compare the asset_data_to_redshift.py output to the expected results
```
Report: asset_data_to_redshift.py


Config: config.d/GDXDSD-6356_intranet_assets.json


Microservice started at: 2024-02-20 16:15:17-0800 (PST), ended at: 2024-02-20 16:15:53-0800 (PST), elapsing: 0:00:35.675576.


Objects to process: 1
Objects successfully processed: 1
Objects that failed to process: 0
Objects output to 'processed/good': 1
Objects output to 'processed/bad': 0
Objects loaded to Redshift: 1
Empty Objects: 0


List of objects successfully fully ingested from S3, processed, loaded to S3 ('good'), and copied to Redshift:
1: client/doug_test/GDXDSD-6356/cmslite_gdx/intranet_apache.2024-02-19
```
4. Run the following command to test the build_derived_assets.py microservice:
```
$ pipenv run python build_derived_assets.py config.d/GDXDSD-6356_intranet_assets.json 
```
5. Compare the build_derived_assets.py output to the expected results:
```


Report build_derived_assets.py:


Config: config.d/GDXDSD-6356_intranet_assets.json


Microservice started at: 2024-02-20 16:20:22-0800 (PST), ended at: 2024-02-20 16:21:04-0800 (PST), elapsing: 0:00:41.176539.


Objects to process: 1
Objects that failed to process: 0
Objects loaded to Redshift: 1


List of tables successfully parsed, and copied to the derived table in Redshift:
test.gdxdsd6356_asset_downloads


-----------------


```
6. Run the following command to test the cmslite_user_data_to_redshift.py microservice
```
$ pipenv run python cmslite_user_data_to_redshift.py config.d/GDXDSD-6356_cmslite_user_group_metadata.json 
```
7. Compare the cmslite_user_data_to_redshift.py output to the expected results:
```
Report cmslite_user_data_to_redshift.py:


Config: config.d/GDXDSD-6356_cmslite_user_group_metadata.json


Microservice started at: 2024-02-22 14:49:52-0800 (PST), ended at: 2024-02-22 14:50:53-0800 (PST), elapsing: 0:01:01.098970.


Objects to process: 1
Objects successfully processed: 1
Objects that failed to process: 0
Objects output to 'processed/good': 1
Objects output to 'processed/bad': 0
Tables loaded to Redshift: 4/4


List of objects successfully fully ingested from S3, processed, loaded to S3 ('good'), and copied to Redshift:
client/doug_test/GDXDSD-6356/cmslite_gdx/cms-analytics-csv.2024-02-21.tgz
```
8. Check the current contents of the test.microservice_iam_key_rotation table:
```
$ microservice_rs
SET
psql (9.2.24, server 8.0.2)
WARNING: psql version 9.2, server version 8.0.
         Some psql features might not work.
SSL connection (cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256)
Type "help" for help.


snowplow=> select * from test.microservice_iam_key_rotation;
 verification_phrase 
---------------------
(0 rows)


snowplow=> \q
```
9. Run the following command to test the s3_to_redshift.py microservice
```
$ pipenv run python s3_to_redshift.py config.d/test.microservice_iam_key_rotation.json
```
10. Compare the s3_to_redshift.py output to the expected results:
```
Report: s3_to_redshift.py


Config: config.d/test.microservice_iam_key_rotation.json


Microservice started at: 2024-02-22 16:38:42-0800 (PST), ended at: 2024-02-22 16:39:04-0800 (PST), elapsing: 0:00:22.065168.


Objects to process: 1
Objects successfully processed: 1
Objects that failed to process: 0
Objects output to 'processed/good': 1
Objects output to 'processed/bad': 0
Objects loaded to Redshift: 1
Empty Objects: 0




List of objects successfully fully ingested from S3, processed, loaded to S3 ('good'), and copied to Redshift:
1: client/test_microservice-iam-key/GDXDSD-6356-manual1.csv
```
11. Re-check the contents of the test.microservice_iam_key_rotation table:
```
$ microservice_rs
SET
psql (9.2.24, server 8.0.2)
WARNING: psql version 9.2, server version 8.0.
         Some psql features might not work.
SSL connection (cipher: ECDHE-RSA-AES256-GCM-SHA384, bits: 256)
Type "help" for help.


snowplow=> select * from test.microservice_iam_key_rotation;
 verification_phrase 
---------------------
 <EXPECTED_VERIFICATION_PHRASE>
(1 row)


snowplow=> \q
```

### Testing the redshift_to_s3 microservice:

1. Change directory to the redshift_to_s3 microservice:
```
$ cd /home/microservice/branch/GDXDSD-6356_dependabot_urllib3_upgrade_1/redshift_to_s3
```
2. Run the following command to test the redshift_to_s3.py microservice:
```
$ pipenv run python redshift_to_s3.py -c config.d/GDXDSD-6356_pmrp_qdata_daily.json 
```
3. Compare the output of redshift_to_s3.py to the expected results:
```


***The microservice ran successfully***


Report: redshift_to_s3.py


Config: config.d/GDXDSD-6356_pmrp_qdata_daily.json


DML: pmrp_qdata_daily.sql


Microservice started at: 2024-02-23 14:55:08-0800 (PST), ended at: 2024-02-23 14:55:11-0800 (PST), elapsing: 0:00:02.931479.




Objects loaded to S3 /batch: 1/1
Objects successfully loaded to S3 /batch: 1


List of objects successfully loaded to S3 /batch
1. processed/batch/client/doug_test/GDXDSD-6356/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20240223T225508




Objects to store: 1
Objects stored to s3 /client: 1


List of objects stored to S3 /client:
1: client/doug_test/GDXDSD-6356/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20240223T225508_part000




Objects to process: 1
Objects processed to s3 /good: 1


List of objects processed to S3 /good:
1: processed/good/client/doug_test/GDXDSD-6356/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20240223T225508_part000 
```

### Testing the s3_to_sfts microservice:

1. Change the directory to the s3_to_sfts microservice
```
$ cd /home/microservice/branch/GDXDSD-6356_dependabot_urllib3_upgrade_1/s3_to_sfts
```
2. Run the following command to test the s3_to_sfts.py microservice:
```
$ pipenv run python s3_to_sfts.py -c config.d/GDXDSD-6356_pmrp_qdata_daily.json 
```
3. Compare the output of s3_to_sfts.py to the expected results:
```
Report: s3_to_sfts.py


Config: config.d/GDXDSD-6356_pmrp_qdata_daily.json
***The microservice ran successfully***




Microservice started at: 2024-02-23 15:28:19-0800 (PST), ended at: 2024-02-23 15:28:26-0800 (PST), elapsing: 0:00:06.813397.


Items to process: 1
Objects successfully processed to sfts: 1
Objects that failed to process to sfts: 0
Objects successfully processed to s3: 1
Objects that failed to process to s3: 0


List of objects processed to sfts:


1: client/doug_test/GDXDSD-6356/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20240223T013002_part000


List of objects copied to S3 good archives:


1: client/doug_test/GDXDSD-6356/pmrp_qdata/daily/Jun_2022_change/pmrp_qdata_20240223T013002_part000
```
