### PR TITLE
Gdxdsd 5682 fix redshift to s3 mishandling unspecified subfolders

### DIFF
--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -293,7 +293,7 @@ def report(data):
         print(f'\nList of objects processed to S3 /good:')
         if data['good_objects_list']:
             for i, item in enumerate(data['good_objects_list'], 1):
-                print(f"{i}: {good_prefix}/{item}")
+                print(f"{i}: {item}")
 
     # Print all objects loaded into s3/bad
     if data["bad_objects"]:
@@ -301,7 +301,7 @@ def report(data):
         print(f'\nList of objects processed to S3 /bad:')
         if data['bad_objects_list']:
             for i, item in enumerate(data['bad_objects_list'], 1):
-                print(f"{i}: {bad_prefix}/{item}")
+                print(f"{i}: {item}")
 
 # Reporting variables. Accumulates as the the loop below is traversed
 report_stats = {
@@ -533,7 +533,7 @@ with psycopg2.connect(conn_string) as conn:
                         Key=copy_bad_prefix)
                     logger.info('Copied from s3://%s/%s', bucket, copy_from_prefix)
                     logger.info('Copied to s3://%s/%s', bucket, copy_bad_prefix)
-                    report_stats['bad_objects_list'].append(filename)
+                    report_stats['bad_objects_list'].append(copy_bad_prefix)
                     report_stats['bad_objects'] += 1
                     
                     report(report_stats)
@@ -552,7 +552,7 @@ with psycopg2.connect(conn_string) as conn:
                     logger.info('Copied from s3://%s/%s', bucket, copy_from_prefix)
                     logger.info('Copied to s3://%s/%s', bucket, copy_good_prefix)
                     report_stats['good_objects'] += 1
-                    report_stats['good_objects_list'].append(filename)
+                    report_stats['good_objects_list'].append(copy_good_prefix)
 
             report(report_stats)
             clean_exit(0,'Finished succesfully.')

--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -275,7 +275,7 @@ def report(data):
         print(f'\nList of objects stored to S3 /client:')
         if data['stored_objects_list']:
             for i, item in enumerate(data['stored_objects_list'], 1):
-                print(f"{i}: {storage_prefix}/{item}")
+                print(f"{i}: {item}")
 
     # Print all objects not loaded into s3/client
     if data["unstored_objects"]:
@@ -283,7 +283,7 @@ def report(data):
         print(f'\nList of objects not stored to S3 /client:')
         if data['unstored_objects_list']:
             for i, item in enumerate(data['unstored_objects_list'], 1):
-                print(f"{i}: {storage_prefix}/{item}")
+                print(f"{i}: {item}")
 
     print(f'\n\nObjects to process: {data["unprocessed_objects"]}')
 

--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -438,8 +438,10 @@ def get_unprocessed_objects():
     for object_summary in res_bucket.objects.filter(Prefix=f'{batch_prefix}/'): # batch_prefix may need a trailing /
         key = object_summary.key
         filename = key[key.rfind('/')+1:]  # get the filename (after the last '/')
-        goodfile = f"{good_prefix}/{filename}"
-        badfile = f"{bad_prefix}/{filename}"
+        
+        # replaces the batch part of the key with good/bad
+        goodfile = key.replace(f'{archive}/batch/', f'{archive}/good/', 1)
+        badfile = key.replace(f'{archive}/batch/', f'{archive}/bad/', 1)
 
         def is_processed():
             '''Check to see if the file has been processed already'''

--- a/redshift_to_s3/redshift_to_s3.py
+++ b/redshift_to_s3/redshift_to_s3.py
@@ -524,7 +524,7 @@ with psycopg2.connect(conn_string) as conn:
                     logger.exception('Exception copying from s3://%s/%s', bucket, copy_from_prefix)
                     logger.exception('to s3://%s/%s', bucket, copy_to_prefix)
                     report_stats['unstored_objects'] += 1
-                    report_stats['unstored_objects_list'].append(filename_with_extension)
+                    report_stats['unstored_objects_list'].append(copy_from_prefix)
                     
                     logger.info('Copying to s3 /bad ...')
                     client.copy_object(
@@ -542,7 +542,7 @@ with psycopg2.connect(conn_string) as conn:
                     logger.info('Copied from s3://%s/%s', bucket, copy_from_prefix)
                     logger.info('Copied to s3://%s/%s', bucket, copy_to_prefix)
                     report_stats['stored_objects'] += 1
-                    report_stats['stored_objects_list'].append(filename_with_extension)
+                    report_stats['stored_objects_list'].append(copy_to_prefix)
                     
                     logger.info('Copying to s3 /good ...')
                     client.copy_object(


### PR DESCRIPTION
This PR does the following:

1. Fixes bug in redshift_to_s3.py so that S3 object paths are built so that all unspecified subfolders are retained.
2. Rewrites redshift_to_s3.py path building logic so that it is similar to [s3_to_sfts.py](https://github.com/bcgov/GDX-Analytics-microservice/blob/main/s3_to_sfts/s3_to_sfts.py)

There is the possibility with the current redshift_to_s3.py script that objects in subfolders that are not specified in the job's config file will be copied to the wrong client/good/bad paths in S3. This is because the way the S3 object prefixes were built searched for the filename after the last / (slash) and appended it to the prefixes built from the values in the config. If the subfolders were not specified in the config, they were lost in this process.

This scenario is likely to never happen but could potentially occur if something external causes the microservice to fail while it's trying to process the objects through S3. This would happen if the objects created by this failed run are not cleaned up, and this error isn't caught before the next time the microservice is ran.

The test config and S3 buckets are set up in a way to mimic the scenario where an object was successfully unloaded to the batch folder but failed to copy to the client and archive folders. 

Please note that a config file was modified so that the tests can run. The modified config will be added to the ticket.

Testing instructions:
1. Review the changes to [redshift_to_s3/redshift_to_s3.py](https://github.com/bcgov/GDX-Analytics-microservice/compare/main...GDXDSD-5682-fix-redshift-to-s3-mishandling-unspecified-subfolders#diff-2eeca8c9038ae141f9813377781fbc0ecdae4970eee81d011aa026c1331bf5e2)
2. Review the processed batch folder in S3 to check that old files, a sub-folder and sub-file exists: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?prefix=processed/batch/client/doug_test/GDXDSD-5682/main_files/&region=ca-central-1&bucketType=general
3. Review the client and processed good folders in s3 to check that old files exists, but the sub-folder and sub-file do not exist:

- client: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&bucketType=general&prefix=client/doug_test/GDXDSD-5682/main_files/&showversions=false
- processed good: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?prefix=processed/good/client/doug_test/GDXDSD-5682/main_files/&region=ca-central-1&bucketType=general

4. Log into the ec2 instance through the following commands
```
awsmfa prod <AWS OTP>
microservice_ssm
cd /home/microservice/branch/GDXDSD-5682-fix-redshift-to-s3-mishandling-unspecified-subfolders/redshift_to_s3/
```
5. Run the following command and compare its output to what's expected
```
pipenv run python redshift_to_s3.py -c config.d/GDXDSD-5682.json
```
```
***The microservice ran successfully***

Report: redshift_to_s3.py

Config: config.d/GDXDSD-5682.json

DML: pmrp_qdata_daily.sql

Microservice started at: 2024-03-07 11:35:23-0800 (PST), ended at: 2024-03-07 11:35:26-0800 (PST), elapsing: 0:00:03.488324.


Objects loaded to S3 /batch: 1/1
Objects successfully loaded to S3 /batch: 1

List of objects successfully loaded to S3 /batch
1. processed/batch/client/doug_test/GDXDSD-5682/main_files/pmrp_qdata_20240307T193523


Objects to store: 2
Objects stored to s3 /client: 2

List of objects stored to S3 /client:
1: client/doug_test/GDXDSD-5682/main_files/pmrp_qdata_20240307T193523_part000
2: client/doug_test/GDXDSD-5682/main_files/sub_folder/pmrp_qdata_20240304T210614_part000


Objects to process: 2
Objects processed to s3 /good: 2

List of objects processed to S3 /good:
1: processed/good/client/doug_test/GDXDSD-5682/main_files/pmrp_qdata_20240307T193523_part000
2: processed/good/client/doug_test/GDXDSD-5682/main_files/sub_folder/pmrp_qdata_20240304T210614_part000
```
6. Check to see if the file appear in the s3 processed batch bucket (its subfolder has already been populated): https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?prefix=processed/batch/client/doug_test/GDXDSD-5682/main_files/&region=ca-central-1&bucketType=general
7. Check to see if the files appear in the s3 client bucket and its subfolders: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&bucketType=general&prefix=client/doug_test/GDXDSD-5682/main_files/&showversions=false
8. Check to see if the files appear in the s3 processed good bucket and its subfolders: https://s3.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?prefix=processed/good/client/doug_test/GDXDSD-5682/main_files/&region=ca-central-1&bucketType=general