### PR TITLE
Updated config_search.json and removed careertekbc

### DIFF
--- a/google-api/config_search.json
+++ b/google-api/config_search.json
@@ -61,10 +61,6 @@
       "start_date_default": "2020-04-23"
     },
     {
-      "name": "https://www.careertrekbc.ca/",
-      "start_date_default": "2020-04-23"
-    },
-    {
       "name": "https://www.britishcolumbia.ca/",
       "start_date_default": "2019-02-02"
     },


### PR DESCRIPTION
This PR removes careertekbc website from the config_search.json.