### PR TITLE
GDXDSD-7014-removed redundant connection strings

### DIFF
--- a/cmslitemetadata_to_redshift/cmslitemetadata_to_redshift.py
+++ b/cmslitemetadata_to_redshift/cmslitemetadata_to_redshift.py
@@ -112,15 +112,6 @@ def main():
     aws_access_key_id = os.environ['AWS_ACCESS_KEY_ID']
     aws_secret_access_key = os.environ['AWS_SECRET_ACCESS_KEY']
 
-    # prep database call to pull the batch file into redshift
-    conn_string = """
-    dbname='{dbname}' host='{host}' port='{port}' user='{user}' \
-    password={password}
-    """.format(dbname='snowplow',
-               host='redshift.analytics.gov.bc.ca',
-               port='5439',
-               user=os.environ['pguser'],
-               password=os.environ['pgpass'])
 
     # bucket = the S3 bucket
     # filename = the name of the original file being processed

--- a/looker_dashboard_usage/looker_dashboard_usage.py
+++ b/looker_dashboard_usage/looker_dashboard_usage.py
@@ -99,14 +99,6 @@ tables=[
 client = boto3.client('s3')  # low-level functional API
 resource = boto3.resource('s3')  # high-level object-oriented API
 
-# Redshift Database connection string
-rs_conn_string = """
-dbname='{dbname}' host='{host}' port='{port}' user='{user}' password={password}
-""".format(dbname='snowplow',
-           host='redshift.analytics.gov.bc.ca',
-           port='5439',
-           user=os.environ['pguser'],
-           password=os.environ['pgpass'])
 
 # START CHANGES - 2022/11/28 BEO GDXDSD-5398
 def structure_output_item(item_name):

--- a/s3_to_redshift/asset_data_to_redshift.py
+++ b/s3_to_redshift/asset_data_to_redshift.py
@@ -114,16 +114,6 @@ my_bucket = resource.Bucket(bucket)  # subsitute this for your s3 bucket name.
 bucket_name = my_bucket.name
 
 
-# Database connection string
-conn_string = """
-dbname='{dbname}' host='{host}' port='{port}' user='{user}' password={password}
-""".format(dbname='snowplow',
-           host='redshift.analytics.gov.bc.ca',
-           port='5439',
-           user=os.environ['pguser'],
-           password=os.environ['pgpass'])
-
-
 # Constructs the database copy query string
 def copy_query(dbtable, batchfile, log):
     if log:

--- a/s3_to_redshift/build_derived_assets.py
+++ b/s3_to_redshift/build_derived_assets.py
@@ -109,14 +109,6 @@ else:
 
 truncate_intermediate_table = 'TRUNCATE TABLE ' + dbtable + ';'
 
-conn_string = """
-dbname='{dbname}' host='{host}' port='{port}' user='{user}' password={password}
-""".format(dbname='snowplow',
-           host='redshift.analytics.gov.bc.ca',
-           port='5439',
-           user=os.environ['pguser'],
-           password=os.environ['pgpass'])
-
 
 with open('ddl/build_derived_assets.sql', 'r') as file:
     query = file.read()

--- a/s3_to_redshift/cmslite_user_data_to_redshift.py
+++ b/s3_to_redshift/cmslite_user_data_to_redshift.py
@@ -81,15 +81,6 @@ resource = boto3.resource('s3')  # high-level object-oriented API
 my_bucket = resource.Bucket(bucket)  # subsitute this for your s3 bucket name.
 bucket_name = my_bucket.name
 
-# Database connection string
-conn_string = """
-dbname='{dbname}' host='{host}' port='{port}' user='{user}' password={password}
-""".format(dbname='snowplow',
-           host='redshift.analytics.gov.bc.ca',
-           port='5439',
-           user=os.environ['pguser'],
-           password=os.environ['pgpass'])
-
 
 # Constructs the database copy query string
 def copy_query(dbtable, batchfile, log):

--- a/s3_to_redshift/s3_to_redshift.py
+++ b/s3_to_redshift/s3_to_redshift.py
@@ -126,15 +126,6 @@ resource = boto3.resource('s3')  # high-level object-oriented API
 my_bucket = resource.Bucket(bucket)  # subsitute this for your s3 bucket name.
 bucket_name = my_bucket.name
 
-# Database connection string
-conn_string = """
-dbname='{dbname}' host='{host}' port='{port}' user='{user}' password={password}
-""".format(dbname='snowplow',
-           host='redshift.analytics.gov.bc.ca',
-           port='5439',
-           user=os.environ['pguser'],
-           password=os.environ['pgpass'])
-
 
 def copy_query(this_table, this_batchfile, this_log):
     '''Constructs the database copy query string'''


### PR DESCRIPTION
This PR removes redundant database connection strings from the following scripts:

- cmslitemetadata_to_redshift
- looker_dashboard_usage
- cmslite_user_data_to_redshift.py
- s3_to_redshift.py
- asset_data_to_redshift.py
- build_derived_assets.py

See the ticket for testing instructions.