### PR TITLE
changes to sql statement in build_derived_assets.sql

### DIFF
--- a/derived_assets_to_redshift/ddl/build_derived_assets.sql
+++ b/derived_assets_to_redshift/ddl/build_derived_assets.sql
@@ -1,8 +1,8 @@
 BEGIN;
 SET SEARCH_PATH TO '{schema_name}';
 INSERT INTO asset_downloads_derived (
-SELECT '{asset_scheme_and_authority}' ||
-    SPLIT_PART(assets.request_string, ' ',2)
+SELECT LEFT ('{asset_scheme_and_authority}' || 
+    SPLIT_PART(assets.request_string, ' ',2), 4093)
     AS asset_url,
 assets.date_timestamp::TIMESTAMP,
 assets.ip AS ip_address,


### PR DESCRIPTION

This PR changes the SQL statement in build_derived_assets.sql to limit the string length to 4093 characters.

Please refer to the ticket GDXDSD-7499 for the testing instructions.