### PR TITLE
Removed healthlinkbc.ca

### DIFF
--- a/google_search/config.d/config_search.json
+++ b/google_search/config.d/config_search.json
@@ -105,9 +105,6 @@
       "start_date_default": "2021-07-04"
     },
     {
-      "name": "https://www.healthlinkbc.ca"
-    },
-    {
       "name": "https://www.broadwaysubway.ca/",
       "start_date_default": "2022-08-29"
     },


### PR DESCRIPTION
Removed healthlinkbc.ca from this site until their google search console verification is being fixed in GDXDSD-7702