### PR TITLE
Updated protobuf to v5.29.5

### DIFF
--- a/google_search/Pipfile.lock
+++ b/google_search/Pipfile.lock
@@ -278,20 +278,20 @@
         },
         "protobuf": {
             "hashes": [
-                "sha256:0c4eec6f987338617072592b97943fdbe30d019c56126493111cf24344c1cc24",
-                "sha256:135658402f71bbd49500322c0f736145731b16fc79dc8f367ab544a17eab4535",
-                "sha256:27b246b3723692bf1068d5734ddaf2fccc2cdd6e0c9b47fe099244d80200593b",
-                "sha256:3e6101d095dfd119513cde7259aa703d16c6bbdfae2554dfe5cfdbe94e32d548",
-                "sha256:3fa2de6b8b29d12c61911505d893afe7320ce7ccba4df913e2971461fa36d584",
-                "sha256:64badbc49180a5e401f373f9ce7ab1d18b63f7dd4a9cdc43c92b9f0b481cef7b",
-                "sha256:70585a70fc2dd4818c51287ceef5bdba6387f88a578c86d47bb34669b5552c36",
-                "sha256:712319fbdddb46f21abb66cd33cb9e491a5763b2febd8f228251add221981135",
-                "sha256:91fba8f445723fcf400fdbe9ca796b19d3b1242cd873907979b9ed71e4afe868",
-                "sha256:a3f6857551e53ce35e60b403b8a27b0295f7d6eb63d10484f12bc6879c715687",
-                "sha256:cee1757663fa32a1ee673434fcf3bf24dd54763c79690201208bafec62f19eed"
+                "sha256:bc1463bafd4b0929216c35f437a8e28731a2b7fe3d98bb77a600efced5a15c84",
+                "sha256:6cf42630262c59b2d8de33954443d94b746c952b01434fc58a417fdbd2e84bd5",
+                "sha256:3f76e3a3675b4a4d867b52e4a5f5b78a2ef9565549d4037e06cf7b0942b1d3fc",
+                "sha256:3f1c6468a2cfd102ff4703976138844f78ebd1fb45f49011afc5139e9e283079",
+                "sha256:470f3af547ef17847a28e1f47200a1cbf0ba3ff57b7de50d22776607cd2ea353",
+                "sha256:6f642dc9a61782fa72b90878af134c5afe1917c89a568cd3476d758d3c3a0736",
+                "sha256:7318608d56b6402d2ea7704ff1e1e4597bee46d760e7e4dd42a3d45e24b87f2e",
+                "sha256:ef91363ad4faba7b25d844ef1ada59ff1604184c0bcd8b39b8a6bef15e1af238",
+                "sha256:63848923da3325e1bf7e9003d680ce6e14b07e55d0473253a690c3a8b8fd6e61",
+                "sha256:fa18533a299d7ab6c55a238bf8629311439995f2e7eca5caaff08663606e9015",
+                "sha256:e38c5add5a311f2a6eb0340716ef9b039c1dfa428b28f25a7838ac329204a671"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==5.28.3"
+            "version": "==5.29.5"
         },
         "psycopg2-binary": {
             "hashes": [


### PR DESCRIPTION
### This PR does the following
Updates google_search's protobuf package to version 5.29.5
This is done manually to align with automated dependabot updates by editing the Pipfile.lock file, changing the version for protobuf and updating the hashes with the ones found in https://pypi.org/project/protobuf/5.29.5/#files

Please note that some files were modified for testing purposes. You can see these modified files attached in the ticket.

### Login to development environment

1. Run the following command to login to EC2
```
$ awsmfa prod ######
Generating new IAM STS Token ...
STS Session Token generated and saved in profile mfa successfully.
$ microservice_ssm
```
2. Run the following command to change to the development branch:
```
cd /home/microservice/branch/GDXDSD-7892_dependabot58_protobuf/google_search
```

### Review files

Review the following files and compare them with the test files provided in the ticket

1. Check [Pipfile.lock](https://github.com/bcgov/GDX-Analytics-microservice/blob/GDXDSD-7892_dependabot58_protobuf/google_search/Pipfile.lock#L279) to make sure the protobuf entry is set to version 5.29.5

### Testing instructions:

1. Install the virtual environment using Pipfile.lock
```
/home/microservice/.local/bin/pipenv install --ignore-pipfile
```
2. Verify that the virtual environment is using protobuf v5.29.5 using the following command
```
/home/microservice/.local/bin/pipenv graph | grep protobuf
```
Output:
```
│   │   └── protobuf [required: >=3.20.2,<6.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=3.20.1,!=3.20.0, installed: 5.29.5]
│   │   └── protobuf [required: >=3.19.0,<6.0.0dev, installed: 5.29.5]
│   ├── protobuf [required: >=3.19.5,<6.0.0.dev0,!=4.21.5,!=4.21.4,!=4.21.3,!=4.21.2,!=4.21.1,!=4.21.0,!=3.20.1,!=3.20.0, installed: 5.29.5]
```
3. Run the following commands to test the new jobs, and compare to the expected output:
```
/home/microservice/.local/bin/pipenv run python3.8 google_search.py -o credentials_search.json -a credentials_search.dat -c config.d/GDXDSD-7892_config_search.json
```
```
Report: google_search.py

Config: config.d/GDXDSD-7892_config_search.json

Google Search derived table build not attempted
Microservice started at: 2025-08-21 15:23:15-0700 (PDT), ended at: 2025-08-21 15:23:15-0700 (PDT), elapsing: 0:00:00.000047.

Sites to process: 2
Successful API calls: 2
Failed API calls: 0
Failed loads to RedShift: 0


Objects loaded to S3 and copied to RedShift:
1: s3://sp-ca-bc-gov-131565110619-12-microservices/client/doug_test/GDXDSD-7892/google_gdx/googlesearch-news.gov.bc.ca-2025-08-15-2025-08-19.csv

```
4. Check to make sure the file specified in the console output appears in the s3 client folder: https://ca-central-1.console.aws.amazon.com/s3/buckets/sp-ca-bc-gov-131565110619-12-microservices?region=ca-central-1&bucketType=general&prefix=client/doug_test/GDXDSD-7892/google_gdx/&showversions=false
5. Truncate data from the test table:
```
$ microservice_rs
snowplow=> truncate table test.gdxdsd7892_googlesearch;
TRUNCATE TABLE and COMMIT TRANSACTION
snowplow=> \q
$ 
```
